### PR TITLE
do not use jinja2 map filter with default param

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,12 +16,14 @@
 - name: Install and configure required providers
   vars:
     __certificate_providers: |
-      {{
-        certificate_requests |
-        map(attribute='provider', default=__certificate_provider_default) |
-        unique |
-        list
-      }}
+      {% set ns = namespace(unique_providers=[]) %}
+      {% for item in certificate_requests %}
+      {%   set _ = ns.unique_providers.append(
+             item.provider |
+             d(__certificate_provider_default)
+           ) %}
+      {% endfor %}
+      {{ ns.unique_providers | unique }}
   block:
     - name: Ensure provider packages are installed
       package:


### PR DESCRIPTION
support for the map filter with default was added in jinja2 2.11.0
https://jinja.palletsprojects.com/en/2.11.x/changelog/#version-2-11-0
But some of our supported platforms use jinja2 2.10, so we need to
rewrite the code to not use map/default.

Jinja2 gives warnings/errors like this:
```
TASK [linux-system-roles.certificate : Ensure provider packages are installed] ***
task path: tasks/main.yml:26
[WARNING]: Falling back to Ansible unique filter as Jinja2 one failed:
Unexpected keyword argument 'default'
...
TASK [linux-system-roles.certificate : Ensure certificate requests] ************
task path: tasks/main.yml:104
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.fedorahosted.certmonger was not provided by any .service files
failed: [image.qcow2] (item={'name': 'mycert', 'dns': 'www.example.com'....
```