### PR TITLE
Update version of ansible-freeipa

### DIFF
--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -12,7 +12,7 @@
 - name: Clone ansible-freeipa repo
   git:
     repo: https://github.com/freeipa/ansible-freeipa
-    version: v0.1.12
+    version: v0.2.0
     dest: /tmp/freeipa-repo
   delegate_to: 127.0.0.1
   become: false


### PR DESCRIPTION
Change version of ansible-freeipa to 0.2.0 to fix IPA_MODULES import
issue

https://github.com/linux-system-roles/certificate/issues/60