### PR TITLE
Fixing flake8 E402 errors.

### DIFF
--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.certificate.providers import PROVIDERS
+
+
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",
     "status": ["preview"],
@@ -274,10 +278,6 @@ EXAMPLES = """
 """
 
 RETURN = ""
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.certificate.providers import PROVIDERS
-
 
 KEY_USAGE_CHOICES = [
     "digitalSignature",


### PR DESCRIPTION
+ python -m flake8 --ignore=E501 .
./plugins/modules/certificate_request.py:278:1: E402 module level import not at top of file
from ansible.module_utils.basic import AnsibleModule
^

./plugins/modules/certificate_request.py:279:1: E402 module level import not at top of file
from ansible_collections.fedora.system_roles.plugins.module_utils.certificate.providers.__init__ import PROVIDERS
^
2     E402 module level import not at top of file