### PR TITLE
Collections - workaround for the module_utils path finding issue in ansible 2.9

### DIFF
--- a/module_utils/certificate_lsr/providers/__init__.py
+++ b/module_utils/certificate_lsr/providers/__init__.py
@@ -1,8 +1,7 @@
-from ansible.module_utils.certificate_lsr.providers.certmonger import (
-    CertificateRequestCertmongerProvider,
-)
+from ansible.module_utils.certificate_lsr.providers import certmonger
+
 
 # fmt: off
 PROVIDERS = (
-    ("certmonger", CertificateRequestCertmongerProvider),
+    ("certmonger", certmonger.CertificateRequestCertmongerProvider),
 )

--- a/module_utils/certificate_lsr/providers/certmonger.py
+++ b/module_utils/certificate_lsr/providers/certmonger.py
@@ -2,9 +2,7 @@ from distutils.version import StrictVersion
 
 import dbus
 
-from ansible.module_utils.certificate_lsr.providers.base import (
-    CertificateRequestBaseProvider,
-)
+from ansible.module_utils.certificate_lsr.providers import base
 
 
 class CertmongerDBus:
@@ -49,7 +47,7 @@ class CertmongerDBus:
         ]
 
 
-class CertificateRequestCertmongerProvider(CertificateRequestBaseProvider):
+class CertificateRequestCertmongerProvider(base.CertificateRequestBaseProvider):
     """Certmonger provider for certificate Linux System Role."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Testing the suggestion from @sivel:
Applying this network example to certificate:
  replacing
  from ansible.module_utils.network_lsr.nm.provider import NetworkManagerProvider,
  with
  from ansible.module_utils.network_lsr.nm import provider
  and then use provider.NetworkManagerProvider