### PR TITLE
Use latest pip.

### DIFF
--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -8,6 +8,13 @@
     name:
       - python3
 
+- name: Install the package, force upgrade
+  pip:
+    name: pip
+    state: latest
+    virtualenv: "{{ __virtualenv_path }}"
+    virtualenv_command: /usr/bin/python3 -m venv
+
 - name: Install certreader
   pip:
     name: certreader>=0.1.1


### PR DESCRIPTION
Tests was failing with dependency issue while
installing certreader as pip was installed with older version.
Thus added fix to use latest pip.

Signed-off-by: Anuja More <amore@redhat.com>