### PR TITLE
use molecule v3, drop v2 - use tox-lsr 2.1.2

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@1.0.2"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.1.2"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   LSR_EXTRA_PACKAGES: libdbus-1-dev

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,9 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
-lint:
-  enabled: false
+  name: ${LSR_MOLECULE_DRIVER:-docker}
 platforms:
   - name: centos-7
     image: registry.centos.org/centos/systemd:latest
@@ -22,8 +20,6 @@ platforms:
 provisioner:
   name: ansible
   log: true
-  lint:
-    enabled: false
   playbooks:
     converge: ../../tests/tests_default.yml
 scenario:


### PR DESCRIPTION
Switch to molecule v3.  This drops support for v2.
This requires tox-lsr 2 or later.
Upgrade to tox-lsr 2.1.2 to pick up fix for collection dependency
on python six.