### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
 
   galaxy_tags:
     - centos

--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -30,6 +30,11 @@
     - ipaclient
   when: not __is_beaker_env
 
+- name: ensure hostname package is installed
+  package:
+    name: hostname
+    state: present
+
 - name: Set hostname
   hostname:
     name: ipaserver.test.local


### PR DESCRIPTION
From now the `rhel-8-y` status is the latest unreleased RHEL-8 and the `rhel-x` status is pre-released RHEL-9.

