### PR TITLE
RHELPLAN-69928  Add a note to each module Doc to indicate it is private

### DIFF
--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -15,6 +15,7 @@ DOCUMENTATION = """
 module: certificate_request
 short_description: Manage SSL/TLS certificates.
 description:
+  - "WARNING: Do not use this module directly! It is only for role internal use."
   - The C(certificate_request) module takes a name, desired
     certificate request attributes and certificate properties.
   - The request is generated and sent to the CA to sign.


### PR DESCRIPTION
Adding "WARNING: Do not use this module directly! It is only for role internal use." to certificate_request DOCUMENTATION.