### PR TITLE
tests: Install latest certmonger from updates-testing

### DIFF
--- a/tests/tasks/setup.yml
+++ b/tests/tasks/setup.yml
@@ -1,0 +1,7 @@
+# These steps run for *all* tests
+
+- name: setup - get fix for https://pagure.io/certmonger/issue/223
+  dnf:
+    name: certmonger
+    state: latest
+    enablerepo: updates-testing

--- a/tests/tests_basic_self_signed.yml
+++ b/tests/tests_basic_self_signed.yml
@@ -1,4 +1,9 @@
 ---
+- name: Setup
+  hosts: all
+  tasks:
+    - include_tasks: tasks/setup.yml
+
 - name: Issue simple self-signed certificate
   hosts: all
 


### PR DESCRIPTION
Current Fedora certmonger has a regression with parsing `Extension::`
fields (https://pagure.io/certmonger/issue/223). This is fixed in
updates-proposed. Ensure the tests install that package to unbreak them.

----

This should fix at least the Fedora failures in [recent PRs](https://github.com/linux-system-roles/certificate/pull/94). This is obviously a hack, I don't know how often your test images get refreshed. It's also fine for me to not merge this and just wait for the fix to land, but it somehow breaks *all* operating systems (including CentOS/RHEL 7). Something recent from Fedora is clearly leaking into these VMs, but I didn't track down what exactly. This should help at least a little bit, so that I can start sending some actual fixes. 