### PR TITLE
Fix parser fail on certificate verification.

### DIFF
--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -17,7 +17,9 @@
 
 - name: Install certreader
   pip:
-    name: certreader>=0.1.1
+    name:
+      - cryptography<35
+      - certreader>=0.1.1
     virtualenv: "{{ __virtualenv_path }}"
     virtualenv_command: /usr/bin/python3 -m venv
 


### PR DESCRIPTION
Due to a change in Python's cryptography version 35.0.0 certificate
parser, and a difference in the ASN.1 certificate spec interpretation,
the certificates generated by certmonger fail to be validated.

This patch forces the version for the 'cryptography' package installed
to ignore the affected version, and should allow the tests for this
role to be executed.

certmonger already has a fix for the issue, but it might not be
available for every release supported by certificate role.