### PR TITLE
Remove the unnecessary code

### DIFF
--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -160,7 +160,7 @@ options:
     description:
       - Command that should run after saving the certificate.
     required: false
-  ansible_managed_new:
+  __header:
     description:
       - Ansible ansible_managed string to put in header of file
       - should be in the format of {{ ansible_managed | comment }}
@@ -366,7 +366,7 @@ class CertificateRequestModule(AnsibleModule):
             wait=dict(type="bool", default=True),
             run_before=dict(type="str"),
             run_after=dict(type="str"),
-            ansible_managed_new=dict(type="str"),
+            __header=dict(type="str"),
         )
 
     @property

--- a/module_utils/certificate_lsr/providers/base.py
+++ b/module_utils/certificate_lsr/providers/base.py
@@ -547,9 +547,9 @@ class CertificateRequestBaseProvider:
         """Path where key should be placed."""
         return self._get_store_location(key=True)
 
-    def _get_ansible_managed_new(self):
+    def _get_ansible_managed(self):
         """New ansible managed comment."""
-        return self.module.params.get("ansible_managed_new")
+        return self.module.params.get("__header")
 
     def _get_hook_script_path(self, dirname):
         script_name = "{cert_name}-{request_id}.sh".format(
@@ -574,7 +574,7 @@ class CertificateRequestBaseProvider:
         if not param:
             return None
 
-        script = ["#!/bin/bash", self._get_ansible_managed_new(), param]
+        script = ["#!/bin/bash", self._get_ansible_managed(), param]
         return "\n".join(script)
 
     @property
@@ -676,15 +676,6 @@ class CertificateRequestBaseProvider:
 
         # if file and param are the same just return
         if param_sha1 == file_sha1:
-            # Even if file and param are identical,
-            # if the script exists and the content of the script
-            # is different from the current one including the
-            # ansible managed comment, update the script.
-            cur_script = open(filepath, encoding="utf-8").read()
-            if param != cur_script:
-                with open(filepath, "w") as script_fp:
-                    script_fp.write(param)
-                return True
             return False
 
         # Changes needs to be performed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,8 +140,8 @@
     run_before: "{{ item.run_before | default(omit) }}"
     run_after: "{{ item.run_after | default(omit) }}"
     ca: "{{ item.ca | default(omit) }}"
-    ansible_managed_new: "{{ __certificate_new_header }}"
+    __header: "{{ __lsr_ansible_managed }}"
   loop: "{{ certificate_requests }}"
   vars:
-    __certificate_new_header: "{{
+    __lsr_ansible_managed: "{{
       lookup('template', 'get_ansible_managed.j2') }}"


### PR DESCRIPTION
In the condition of param_sha1 == file_sha1, the condition "param !=
cur_script (contents of file)" never be true and never be executed.
It was introduced in commit e5fe0392f5491293719eddbf5afb29611748c55c
System Roles should consistently use ansible_managed in configuration files it manages

Replace ansible_managed_new with __header

@richm, @rjeffman, so sorry... I revisited the commit e5fe0392f5491293719eddbf5afb29611748c55c and realized it introduced the code which never been executed. This patch removes it. It does not do a bad thing, but we should not include the garbage... :(

And if ok, I'd like to replace the parameter `ansible_managed_new` with `__header` to adjust to the other roles. Thanks.