### PR TITLE
Let each test use a different certificate file name

### DIFF
--- a/tests/tests_basic_ipa.yml
+++ b/tests/tests_basic_ipa.yml
@@ -11,7 +11,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_basic_ipa
         dns: ipaserver.test.local
         principal: HTTP/ipaserver.test.local@TEST.LOCAL
         ca: ipa
@@ -29,8 +29,8 @@
   become: true
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_basic_ipa.crt
+        key_path: /etc/pki/tls/private/mycert_basic_ipa.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_basic_self_signed.yml
+++ b/tests/tests_basic_self_signed.yml
@@ -4,7 +4,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_basic_self_signed
         dns: www.example.com
         ca: self-sign
   roles:
@@ -14,8 +14,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_basic_self_signed.crt
+        key_path: /etc/pki/tls/private/mycert_basic_self_signed.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_dns_ip_email.yml
+++ b/tests/tests_dns_ip_email.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_dns_ip_email
         common_name: My Certificate with SAN
         dns:
           - sub1.example.com
@@ -25,8 +25,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_dns_ip_email.crt
+        key_path: /etc/pki/tls/private/mycert_dns_ip_email.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_fs_attrs.yml
+++ b/tests/tests_fs_attrs.yml
@@ -14,7 +14,7 @@
   hosts: all
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_fs_attrs
         dns: www.example.com
         owner: ftp
         group: ftp
@@ -32,8 +32,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_fs_attrs.crt
+        key_path: /etc/pki/tls/private/mycert_fs_attrs.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_key_size.yml
+++ b/tests/tests_key_size.yml
@@ -4,7 +4,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_key_size
         dns: www.example.com
         ca: self-sign
         key_size: 4096
@@ -15,8 +15,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_key_size.crt
+        key_path: /etc/pki/tls/private/mycert_key_size.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_key_usage_and_extended_key_usage.yml
+++ b/tests/tests_key_usage_and_extended_key_usage.yml
@@ -4,7 +4,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_key_usage_and_extended_key_usage
         dns: www.example.com
         key_usage:
           - digitalSignature
@@ -23,8 +23,9 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_key_usage_and_extended_key_usage.crt
+        key_path: >-
+          /etc/pki/tls/private/mycert_key_usage_and_extended_key_usage.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_many_self_signed.yml
+++ b/tests/tests_many_self_signed.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_many_self_signed
         dns: www.example.com
         ca: self-sign
       - name: other-cert
@@ -19,8 +19,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_many_self_signed.crt
+        key_path: /etc/pki/tls/private/mycert_many_self_signed.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_no_auto_renew.yml
+++ b/tests/tests_no_auto_renew.yml
@@ -4,7 +4,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_no_auto_renew
         dns: www.example.com
         ca: self-sign
         auto_renew: no
@@ -18,8 +18,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_no_auto_renew.crt
+        key_path: /etc/pki/tls/private/mycert_no_auto_renew.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_not_wait_for_cert.yml
+++ b/tests/tests_not_wait_for_cert.yml
@@ -5,7 +5,7 @@
   vars:
     certificate_wait: false
     certificate_requests:
-      - name: mycert
+      - name: mycert_not_wait_for_cert
         dns: www.example.com
         ca: self-sign
   roles:
@@ -15,8 +15,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_not_wait_for_cert.crt
+        key_path: /etc/pki/tls/private/mycert_not_wait_for_cert.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_principal.yml
+++ b/tests/tests_principal.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_principal
         dns: www.example.com
         principal: HTTP/www.example.com@EXAMPLE.COM
         ca: self-sign
@@ -14,8 +14,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_principal.crt
+        key_path: /etc/pki/tls/private/mycert_principal.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_provider.yml
+++ b/tests/tests_provider.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_provider
         dns: www.example.com
         ca: self-sign
         provider: certmonger
@@ -14,8 +14,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_provider.crt
+        key_path: /etc/pki/tls/private/mycert_provider.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_run_hooks.yml
+++ b/tests/tests_run_hooks.yml
@@ -4,7 +4,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_run_hooks
         dns: www.example.com
         ca: self-sign
         run_before: >
@@ -18,8 +18,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_run_hooks.crt
+        key_path: /etc/pki/tls/private/mycert_run_hooks.key
         subject:
           - name: commonName
             oid: 2.5.4.3

--- a/tests/tests_subject.yml
+++ b/tests/tests_subject.yml
@@ -4,7 +4,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_subject
         dns: www.example.com
         common_name: Some other common name
         country: US
@@ -20,8 +20,8 @@
   hosts: all
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_subject.crt
+        key_path: /etc/pki/tls/private/mycert_subject.key
         subject:
           - name: countryName
             oid: 2.5.4.6

--- a/tests/tests_subject_complex.yml
+++ b/tests/tests_subject_complex.yml
@@ -5,7 +5,7 @@
 
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_subject_complex
         dns: www.example.com
         common_name: '# \\Every"thing+that,ne;eds<escap>ing\0 '
         contact_email: admin@example.com
@@ -18,8 +18,8 @@
   become: true
   vars:
     certificates:
-      - path: /etc/pki/tls/certs/mycert.crt
-        key_path: /etc/pki/tls/private/mycert.key
+      - path: /etc/pki/tls/certs/mycert_subject_complex.crt
+        key_path: /etc/pki/tls/private/mycert_subject_complex.key
         subject:
           - name: emailAddress
             oid: 1.2.840.113549.1.9.1

--- a/tests/tests_wrong_provider.yml
+++ b/tests/tests_wrong_provider.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     certificate_requests:
-      - name: mycert
+      - name: mycert_wrong_provider
         dns: www.example.com
         ca: self-sign
         provider: fake-provider


### PR DESCRIPTION
This is part of the effort to allow CI tests run in the serialized
manner on one VM for shortening the duration of the CI tests. In
the current tests, the same certificate file path is shared and
there is no cleaning up implemented. When multiple tests run
sequentially, some attribute, e.g., the file ownership, could be
inherited from the previous tests, which could make the test fail
in the attribute verification. To avoid the false negative failure,
this commit chooses different certificate file name per test.