### PR TITLE
Version 1.1.6 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ Changelog
 
 ### New Features
 
-- make all tests work with gather_facts: false (#121)
-
-Ensure tests work when using ANSIBLE_GATHERING=explicit
+- none
 
 ### Bug Fixes
 
 - none
 
 ### Other Changes
+
+- make all tests work with gather_facts: false (#121)
+
+Ensure tests work when using ANSIBLE_GATHERING=explicit
 
 - make min_ansible_version a string in meta/main.yml (#122)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+[1.1.6] - 2022-07-19
+--------------------
+
+### New Features
+
+- make all tests work with gather_facts: false (#121)
+
+Ensure tests work when using ANSIBLE_GATHERING=explicit
+
+### Bug Fixes
+
+- none
+
+### Other Changes
+
+- make min_ansible_version a string in meta/main.yml (#122)
+
+The Ansible developers say that `min_ansible_version` in meta/main.yml
+must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
+
+- Add CHANGELOG.md (#123)
+
 [1.1.5] - 2022-05-09
 --------------------
 


### PR DESCRIPTION
[1.1.6] - 2022-07-19
--------------------

### New Features

- none

### Bug Fixes

- none

### Other Changes

- make all tests work with gather_facts: false (#121)

Ensure tests work when using ANSIBLE_GATHERING=explicit

- make min_ansible_version a string in meta/main.yml (#122)

The Ansible developers say that `min_ansible_version` in meta/main.yml
must be a `string` value like `"2.9"`, not a `float` value like `2.9`.

- Add CHANGELOG.md (#123)

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
