### PR TITLE
[citest skip] Fix a bash bug in changelog_to_tag.yml, which unexpectedly expanded "*".

### DIFF
--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -22,13 +22,13 @@ jobs:
           pat='\[[0-9]*\.[0-9]*\.[0-9]*\] - [0-9\-]*'
           print=false
           cat CHANGELOG.md | while read -r line; do
-              if [[ $line =~ $pat ]] && [[ $print == false ]]; then
-                  echo $line
+              if [[ "$line" =~ $pat ]] && [[ "$print" == false ]]; then
+                  echo "$line"
                   print=true
-              elif [[ $line =~ $pat ]] && [[ $print == true ]]; then
+              elif [[ "$line" =~ $pat ]] && [[ "$print" == true ]]; then
                   break
-              elif [[ $print == true ]]; then
-                  echo $line
+              elif [[ "$print" == true ]]; then
+                  echo "$line"
               fi
           done > ./.tagmsg.txt
           _tagname=$( grep -m 1 "[0-9]*\.[0-9]*\.[0-9]*" CHANGELOG.md | sed -e "s/^.*\[\([0-9]*\.[0-9]*\.[0-9]*\)\].*/\1/" )


### PR DESCRIPTION
Sorry, there was a bug in the pr "Add changelog_to_tag.yml to .github/workflows (#125)".