### PR TITLE
Move Debian to Python 3 packages

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,10 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
-# Put internal variables here with Debian 10 specific values.
-
-__certificate_packages:
-  - python-pyasn1
-  - python-cryptography
-  - python-dbus
+# Put internal variables here with Debian 11 specific values.
 
 __certificate_default_directory: /etc/ssl


### PR DESCRIPTION
The python 2 packages don't exist any more in current stable Debian 11
and Ubuntu 22.04 LTS. Use the python3-* packages (vars/main.yml has the
correct ones).

---

Spotted in https://github.com/linux-system-roles/cockpit/pull/68 , this role does not work at all any more in current Debian/Ubuntu.