### PR TITLE
WIP: Use distro python cryptography

### DIFF
--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -18,7 +18,7 @@
 - name: Ensure Python's cryptography is installed
   package:
     name: python3-cryptography
-    status: present
+    state: present
 
 - name: Install certreader
   pip:

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -15,10 +15,14 @@
     virtualenv: "{{ __virtualenv_path }}"
     virtualenv_command: /usr/bin/python3 -m venv
 
+- name: Ensure Python's cryptography is installed
+  package:
+    name: python3-cryptography
+    status: present
+
 - name: Install certreader
   pip:
     name:
-      - cryptography<35
       - certreader>=0.1.1
     virtualenv: "{{ __virtualenv_path }}"
     virtualenv_command: /usr/bin/python3 -m venv


### PR DESCRIPTION
Installing Python's cryptography from pip might require that a Rust
compiler is available on the distribution and platform. By using the
distro's package manager to install it, all dependencies will be
available on every supported platform.
