### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ correct ones).
 
 ### Other Changes
 
-- changelog_to_tag action - support other than "master" for the main branch name (#129)
+- changelog_to_tag action - github action ansible test improvements
 
 [1.1.6] - 2022-07-19
 --------------------
@@ -183,14 +183,14 @@ must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
 
 ### Bug fixes
 
-- Fix some ansible-test sanity errors; suppressing the rest
+- Fix some ansible-test errors; suppressing the rest
 - Fix ansible-test errors
 - Add a note to each module Doc to indicate it is private
 
 ### Other Changes
 
 - Remove python-26 environment from tox testing
-- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker
+- update to tox-lsr 2.4.0 - add support for ansible-test with docker
 - CI: Add support for RHEL-9
 
 [1.0.2] - 2021-02-12

--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -10,9 +10,9 @@
   when: __is_beaker_env
 
 - name: Clone ansible-freeipa repo
+  # noqa git-latest
   git:
     repo: https://github.com/freeipa/ansible-freeipa
-    version: master
     dest: /tmp/freeipa-repo
   delegate_to: 127.0.0.1
   become: false


### PR DESCRIPTION
Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

Note: this commit uses the customized woke placed locally in
.github/actions/custom-woke-action. It will be replaced with
the official woke once get-woke/woke#252
(Add an option "--count-only-error-for-failure") is processed.
    
CHANGELOG.md - cleanup non-inclusive words.
tests/tasks/setup_ipa.yml - Apply "wokeignore:rule"