### PR TITLE
Fix assert in tests_run_hooks.yml

### DIFF
--- a/tests/tests_run_hooks.yml
+++ b/tests/tests_run_hooks.yml
@@ -51,16 +51,16 @@
         - name: Assert file created before cert
           assert:
             that:
-              - before_result.stat.mtime < cert_result.stat.mtime
+              - before_result.stat.mtime <= cert_result.stat.mtime
             fail_msg: >-
-              {{ before_result.stat.mtime }} >=
+              {{ before_result.stat.mtime }} >
               {{ cert_result.stat.mtime }}
         - name: Assert file created after cert
           assert:
             that:
-              - after_result.stat.mtime > cert_result.stat.mtime
+              - after_result.stat.mtime >= cert_result.stat.mtime
             fail_msg: >-
-              {{ after_result.stat.mtime }} <=
+              {{ after_result.stat.mtime }} <
               {{ cert_result.stat.mtime }}
 
     - name: Get the ansible_managed comment in pre/post-scripts


### PR DESCRIPTION
In the tests_run_hooks.yml test script, allow the timestamp of run_before and run_after to be equal to the certificate timestamp.
