### PR TITLE
update tox-lsr to 2.13.2; update ansible-lint configuration; start of support for merge queues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,7 @@
 profile: production
 kinds:
   - yaml: "**/meta/collection-requirements.yml"
+  - playbook: "**/tests/get_coverage.yml"
   - yaml: "**/tests/collection-requirements.yml"
   - playbook: "**/tests/tests_*.yml"
   - playbook: "**/tests/setup-snapshot.yml"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,6 +2,11 @@
 name: Ansible Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -2,6 +2,11 @@
 name: Check for ansible_managed variable use in comments
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -25,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -2,6 +2,11 @@
 name: Ansible Plugin Scan
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -25,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,6 +2,11 @@
 name: Ansible Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -28,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,11 @@ on:  # yamllint disable-line rule:truthy
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   schedule:
     - cron: 20 17 * * 4
 jobs:

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -3,6 +3,11 @@
 name: Python Unit Tests
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -46,7 +51,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -69,3 +74,6 @@ jobs:
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Update tox-lsr to 2.13.2

Update ansible-lint configuration

Add support for merge queues to github actions
This doesn't mean all system roles support merge queues,
this is just a preliminary step

See https://github.com/linux-system-roles/.github/pull/21

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
