### PR TITLE
test: check generated files for ansible_managed, fingerprint

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get file
+  slurp:
+    path: "{{ __file }}"
+  register: __content
+
+- name: Check for presence of ansible managed header, fingerprint
+  assert:
+    that:
+      - ansible_managed in content
+      - __fingerprint in content
+  vars:
+    content: "{{ __content.content | b64decode }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment(__comment_type | d("plain")) }}

--- a/tests/tests_run_hooks.yml
+++ b/tests/tests_run_hooks.yml
@@ -63,13 +63,18 @@
               {{ after_result.stat.mtime }} <
               {{ cert_result.stat.mtime }}
 
-    - name: Get the ansible_managed comment in pre/post-scripts
-      command: >-
-        find /etc/certmonger/pre-scripts /etc/certmonger/post-scripts
-        -type f -exec grep "^# Ansible managed" {} \;
-      register: _result
-      changed_when: false
+    - name: Get pre/post-scripts files
+      find:
+        paths:
+          - /etc/certmonger/pre-scripts
+          - /etc/certmonger/post-scripts
+        file_type: file
+      register: __script_files
 
-    - name: Verify the ansible_managed comment in pre/post-scripts
-      assert:
-        that: _result.stdout_lines | length == 2
+    - name: Check generated files for ansible_managed, fingerprint
+      include_tasks: tasks/check_header.yml
+      loop: "{{ __script_files.files | map(attribute='path') | list }}"
+      loop_control:
+        loop_var: __file
+      vars:
+        __fingerprint: "system_role:certificate"


### PR DESCRIPTION
Add the following files: tests/tasks/check_header.yml and
tests/templates/get_ansible_managed.j2.
Use check_header.yml to check generated files for the ansible_managed
and fingerprint headers.
check_header.yml takes two parameters:

* `__file` - required - the full path of the file to check e.g. `/etc/realmd.conf`
* `__fingerprint` - required - the fingerprint string `system_role:$ROLENAME` e.g.
  `__fingerprint: "system_role:postfix"`
* `__comment_type` - optional, default `plain` - the type of comments used

e.g. `__comment_type: c` for C/C++-style comments.  `plain` uses `#`.
See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files
for the different types of comment styles supported.

Example:
```
- name: Check generated files for ansible_managed, fingerprint
  include_tasks: tasks/check_header.yml
  vars:
    __file: /etc/myfile.conf
    __fingerprint: "system_role:my_role"
```
