### PR TITLE
ci: fix pylintrc issues

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -205,13 +205,6 @@ max-line-length=88
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no
@@ -577,11 +570,3 @@ max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception


### PR DESCRIPTION
Remove `no-space-check` and `overgeneral-exception`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
