### PR TITLE
feat: Allow setting certificate and key files mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Alternative Names (SAN).
 | auto_renew           | Indicates if the certificate should be renewed automatically before it expires.                   | bool        | no       | yes                     |
 | owner                | User name (or user id) for the certificate and key files.                                         | str         | no       | *User running Ansible*  |
 | group                | Group name (or group id) for the certificate and key files.                                       | str         | no       | *Group running Ansible* |
+| mode                     | The file system permissions for the certificate and key files.
+  | raw         | no       | -                       |
 | key\_size            | Generate keys with a specific keysize in bits.                                                    | int         | no       | 2048 - See [key\_size](#key_size) |
 | common\_name         | Common Name requested for the certificate subject.                                                | str         | no       | See [common\_name](#common_name)  |
 | country              | Country code requested for the certificate subject.                                               | str         | no       | -                       |

--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -56,6 +56,11 @@ options:
     description:
       - Group name (or group id) for the certificate and key files.
     required: false
+  mode:
+    description:
+      - The file system permissions for the certificate and key files.
+    type: raw
+    required: false
   common_name:
     description:
       - Common Name requested for the certificate subject.
@@ -357,6 +362,7 @@ class CertificateRequestModule(AnsibleModule):
             key_size=dict(type="int", default=2048),
             owner=dict(type="str"),
             group=dict(type="str"),
+            mode=dict(type="raw"),
             principal=dict(type="list"),
             key_usage=dict(
                 type="list", choices=KEY_USAGE_CHOICES, default=KEY_USAGE_DEFAULTS

--- a/module_utils/certificate_lsr/providers/base.py
+++ b/module_utils/certificate_lsr/providers/base.py
@@ -591,9 +591,11 @@ class CertificateRequestBaseProvider:
     def _set_user_and_group_if_different(self):
         owner = self.module.params.get("owner")
         group = self.module.params.get("group")
-        mode = "0640" if group else None
+        mode = self.module.params.get("mode")
+        if group and not mode:
+            mode = "0640"
 
-        if not any([owner, group]):
+        if not any([owner, group, mode]):
             return False
 
         file_attrs = {

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,6 +106,7 @@
     common_name: "{{ item.common_name | default(omit) }}"
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode | default(omit) }}"
     provider: "{{ item.provider | default(omit) }}"
     principal: "{{ item.principal | default(omit) }}"
     directory: "{{ __certificate_default_directory }}"

--- a/tests/tests_fs_attrs.yml
+++ b/tests/tests_fs_attrs.yml
@@ -10,6 +10,7 @@
       group:
         name: somegroup
         gid: 1041
+
 - name: Issue certificate setting user/group
   hosts: all
   vars:
@@ -56,6 +57,57 @@
         owner: 1040
         group: 1041
         mode: "0640"
+  tasks:
+    - name: Verify each certificate
+      include_tasks: tasks/assert_certificate_parameters.yml
+      loop: "{{ certificates }}"
+      loop_control:
+        loop_var: cert
+
+- name: Issue certificate setting user/group/mode
+  hosts: all
+  vars:
+    certificate_requests:
+      - name: mycert_fs_attrs_mode
+        dns: www.example.com
+        owner: ftp
+        group: ftp
+        mode: "0620"
+        ca: self-sign
+      - name: certid_mode
+        dns: www.example.com
+        mode: "0600"
+        ca: self-sign
+
+  roles:
+    - linux-system-roles.certificate
+
+- name: Verify certificate
+  hosts: all
+  vars:
+    certificates:
+      - path: /etc/pki/tls/certs/mycert_fs_attrs_mode.crt
+        key_path: /etc/pki/tls/private/mycert_fs_attrs_mode.key
+        subject:
+          - name: commonName
+            oid: 2.5.4.3
+            value: www.example.com
+        subject_alt_name:
+          - name: DNS
+            value: www.example.com
+        owner: ftp
+        group: ftp
+        mode: "0620"
+      - path: /etc/pki/tls/certs/certid_mode.crt
+        key_path: /etc/pki/tls/private/certid_mode.key
+        subject:
+          - name: commonName
+            oid: 2.5.4.3
+            value: www.example.com
+        subject_alt_name:
+          - name: DNS
+            value: www.example.com
+        mode: "0600"
   tasks:
     - name: Verify each certificate
       include_tasks: tasks/assert_certificate_parameters.yml


### PR DESCRIPTION
Enhancement: Allow seting of certificate and key files mode attribute through the use of the 'mode' parameter, when using the certmonger provider.

Reason: Previously, the certificate files generated by the certmonger provider used a default file mode that may not be suitable for some tools or for some more restricted environments.

Result: The file mode attribute can now be set using the same roles as Ansible's file mode parameter, accepting either a string or an integer.

Issue Tracker Tickets (Jira or BZ if any): https://bugzilla.redhat.com/show_bug.cgi?id=2180902

