### PR TITLE
ci: Use Ubuntu repository for Python 2.7

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -42,7 +42,14 @@ jobs:
       - name: checkout PR
         uses: actions/checkout@v3
 
-      - name: Set up Python
+      - name: Set up Python 2.7
+        if: ${{ matrix.pyver_os.ver == '2.7' }}
+        run: |
+          set -euxo pipefail
+          sudo apt install -y python2.7
+
+      - name: Set up Python 3
+        if: ${{ matrix.pyver_os.ver != '2.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver_os.ver }}


### PR DESCRIPTION
As of June 19th, 2023, Python 2.7 is not available on Github's software cache for Ubuntu 20.04 workflow runners. To keep running unit tests using Python 2.7, the package is installed through Ubunut's repositories using `apt install`.
