### PR TITLE
test: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,27 +3,30 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-      - id: flake8
       - id: detect-private-key
       - id: debug-statements
       - id: check-docstring-first
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.3
+    hooks:
+      - id: flake8
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 5.0.2
+    rev: 6.0.0
     hooks:
       - id: pydocstyle
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.23.0
+    rev: v1.32.0
     hooks:
       - id: yamllint
         entry: yamllint -c .yamllint.yml


### PR DESCRIPTION
Update pre-commit hooks to newer versions as some were failing due to being too old.