### PR TITLE
ci: Remove package installation through pip

### DIFF
--- a/tests/library/certtojson.py
+++ b/tests/library/certtojson.py
@@ -6,6 +6,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from pyasn1.codec.der import decoder
 from pyasn1.type import char, namedtype, tag, univ
+import struct
 
 
 def load_unknown_certificate_from_data(cert_data):
@@ -29,7 +30,10 @@ def parse_cert_timestamp(cert_datetime):
 
 def to_hex_str(value):
     """Convert byte list to "XX:XX:XX..." string."""
-    return ":".join(f"{byte:02X}" for byte in value)
+    # pylint: disable=C0209
+    fmtstr = str(len(value)) + "B"
+    intlist = struct.unpack(fmtstr, value)
+    return ":".join("{0:02X}".format(byte) for byte in intlist)
 
 
 def decode_kerberos_principalname(data):

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -5,25 +5,21 @@
 
 - name: Ensure python3 is installed
   package:
-    name: python3
-
-- name: Ensure packages are updated
-  pip:
     name:
-      - pip
-    state: latest  # noqa package-latest
-    virtualenv: "{{ __virtualenv_path }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+      - python2-cryptography
+      - python2-cryptography
+  when:
+    - ansible_distribution_major_version == "7"
+    - ansible_os_family == "RedHat"
 
-- name: Ensure packages are updated
-  pip:
+- name: Ensure python3 is installed
+  package:
     name:
-      - pip
-      - cryptography
-      - pyasn1
-    state: latest  # noqa package-latest
-    virtualenv: "{{ __virtualenv_path }}"
-    virtualenv_command: /usr/bin/python3 -m venv
+      - python3-cryptography
+      - python3-pyasn1
+  when:
+    - ansible_distribution_major_version != "7"
+    - ansible_os_family == "RedHat"
 
 - name: Retrieve certificate file stats
   stat:
@@ -82,8 +78,6 @@
     filename: "{{ cert['path'] }}"
   register: certificate_data
   changed_when: false
-  vars:
-    ansible_python_interpreter: "{{ __virtualenv_path }}/bin/python"
 
 - name: Load certificate YAML to cert_issued variable
   set_fact:
@@ -119,13 +113,11 @@
     default_ku:
       - digital_signature
       - key_encipherment
+    expected: "{{ cert.key_usage | d(default_ku) | sort }}"
+    actual: "{{ cert_issued.extensions.keyUsage.value | sort }}"
   assert:
-    that:
-      - (cert.key_usage | default(default_ku)) ==
-        cert_issued.extensions.keyUsage.value
-    fail_msg: >-
-      {{ cert.key_usage | default(default_ku) }} !=
-      {{ cert_issued.extensions.keyUsage.value }}
+    that: expected == actual
+    fail_msg: expected value {{ expected }} != {{ actual }}
 
 - name: Verify certificate Extended Key Usage
   vars:
@@ -134,14 +126,11 @@
         oid: 1.3.6.1.5.5.7.3.1
       - name: id-kp-clientAuth
         oid: 1.3.6.1.5.5.7.3.2
+    expected: "{{ cert.extended_key_usage | d(default_eku) }}"
+    actual: "{{ cert_issued.extensions.extendedKeyUsage.value }}"
   assert:
-    that:
-      - (
-          cert.extended_key_usage | default(default_eku)
-        ) == cert_issued.extensions.extendedKeyUsage.value
-    fail_msg: >-
-      {{ cert.extended_key_usage | default(default_eku) }} !=
-      {{ cert_issued.extensions.extendedKeyUsage.value }}
+    that: expected == actual
+    fail_msg: expected value {{ expected }} != {{ actual }}
 
 - name: Retrieve auto-renew flag
   shell: >-


### PR DESCRIPTION
This patch drop usage of pip to download and install test dependencies, and in its place use Ansible's builtin `package` module. The advantage is to use the distribution official packages, which are easier to trace the source.