### PR TITLE
tests: Ensure ipaserver hostname is a FQDN

### DIFF
--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -46,6 +46,8 @@
 - name: Set hostname
   hostname:
     name: ipaserver.test.local
+    use: systemd
+  when: ansible_facts.os_family == "RedHat"
 
 - name: Ensure nss package is up-to-date
   package:


### PR DESCRIPTION
As certificate system role uses an IPA server to test certmonger provider, the ipaserver node has to have a FQDN for IPA to be installed. For the RedHat family of distros, from CentOS/RHEL 7+ and newer, automatic detection of Ansible's hostname may not select 'systemd' strategy, failing to set the hostnade FQDN. This failure often happens when running the tests locally with 'qemu'.

This patch ensure that the 'systemd' strategy is used to set hostname.