### PR TITLE
fix: Re-issue certificate if key size changes

### DIFF
--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -67,9 +67,8 @@ options:
     required: false
   key_size:
     description:
-      - Generate keys with a specific keysize in bits.
+      - Generate keys with a specific keysize in bits, by default 2048.
     required: false
-    default: 2048
   ca:
     description:
       - CA that will issue the certificate. The available options
@@ -359,7 +358,7 @@ class CertificateRequestModule(AnsibleModule):
             directory=dict(type="str", default="/etc/pki/tls"),
             provider_config_directory=dict(type="str", default="/etc/certmonger"),
             provider=dict(type="str", default="certmonger"),
-            key_size=dict(type="int", default=2048),
+            key_size=dict(type="int", default=None),
             owner=dict(type="str"),
             group=dict(type="str"),
             mode=dict(type="raw"),

--- a/module_utils/certificate_lsr/providers/base.py
+++ b/module_utils/certificate_lsr/providers/base.py
@@ -185,6 +185,7 @@ class CertificateProxy:
             "extended_key_usage",
             "principal",
             "auto_renew",
+            "key_size",
         ]
         info = {k: v for k, v in params.items() if k in map_attrs}
 
@@ -254,6 +255,7 @@ class CertificateProxy:
         cert_like = cls(module)
         info = cert_like._get_info_from_x509(x509_obj)
         info["auto_renew"] = auto_renew
+        info["key_size"] = x509_obj.public_key().key_size
         cert_like.cert_data = info
         return cert_like
 

--- a/module_utils/certificate_lsr/providers/certmonger.py
+++ b/module_utils/certificate_lsr/providers/certmonger.py
@@ -264,9 +264,14 @@ class CertificateRequestCertmongerProvider(base.CertificateRequestBaseProvider):
         command += self.set_auto_renew(self.csr.auto_renew)
 
         # Set certificate key size
+        key_size = self.module.params.get("key_size")
         allow_key_size_update = self.certmonger_version >= StrictVersion("0.79.0")
+        if key_size is not None and not allow_key_size_update:
+            self.module.fail_json(
+                msg="Your certmonger version does not support attribute 'key_size'"
+            )
         if not self.exists_in_certmonger or allow_key_size_update:
-            command += ["-g", str(self.module.params.get("key_size"))]
+            command += ["-g", str(key_size)]
 
         self.module.debug("Certmonger command: {0}".format(command))
 

--- a/tests/tests_key_size.yml
+++ b/tests/tests_key_size.yml
@@ -1,33 +1,40 @@
 ---
-- name: Issue simple self-signed certificate
+- name: Test certificate generation with key_size
   hosts: all
 
-  vars:
-    certificate_requests:
-      - name: mycert_key_size
-        dns: www.example.com
-        ca: self-sign
-        key_size: 4096
-  roles:
-    - linux-system-roles.certificate
-
-- name: Verify certificate
-  hosts: all
-  vars:
-    certificates:
-      - path: /etc/pki/tls/certs/mycert_key_size.crt
-        key_path: /etc/pki/tls/private/mycert_key_size.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.com
-        subject_alt_name:
-          - name: DNS
-            value: www.example.com
-        key_size: 4096
   tasks:
-    - name: Verify each certificate
-      include_tasks: tasks/assert_certificate_parameters.yml
-      loop: "{{ certificates }}"
-      loop_control:
-        loop_var: cert
+    - name: Include role, ignore fail if certmonger version is not supported
+      block:
+        - name: Request certificate with key size
+          ansible.builtin.include_role:
+            name: linux-system-roles.certificate
+          vars:
+            certificate_requests:
+              - name: mycert_key_size
+                dns: www.example.com
+                ca: self-sign
+                key_size: 1024
+        - name: Verify each certificate
+          include_tasks: tasks/assert_certificate_parameters.yml
+          loop: "{{ certificates }}"
+          loop_control:
+            loop_var: cert
+          vars:
+            certificates:
+              - path: /etc/pki/tls/certs/mycert_key_size.crt
+                key_path: /etc/pki/tls/private/mycert_key_size.key
+                subject:
+                  - name: commonName
+                    oid: 2.5.4.3
+                    value: www.example.com
+                subject_alt_name:
+                  - name: DNS
+                    value: www.example.com
+                key_size: 1024
+      rescue:
+        - name: Clear host errors if certmonger version is not supported
+          meta: clear_host_errors
+          when: version_error in ansible_failed_result.results[0].msg
+          vars:
+            version_error: >-
+              certmonger version does not support attribute 'key_size'

--- a/tests/tests_key_size_reissue.yml
+++ b/tests/tests_key_size_reissue.yml
@@ -1,0 +1,85 @@
+---
+- name: Test re-issue certificate if key size changes
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Include role, ignore fail if certmonger version is not supported
+      block:
+        - name: Request certificate with key size
+          ansible.builtin.include_role:
+            name: linux-system-roles.certificate
+          vars:
+            certificate_requests:
+              - name: mycert_key_size
+                dns: www.example.com
+                ca: self-sign
+                key_size: 4096
+        - name: Verify each certificate
+          include_tasks: tasks/assert_certificate_parameters.yml
+          loop: "{{ certificates }}"
+          loop_control:
+            loop_var: cert
+          vars:
+            certificates:
+              - path: /etc/pki/tls/certs/mycert_key_size.crt
+                key_path: /etc/pki/tls/private/mycert_key_size.key
+                subject:
+                  - name: commonName
+                    oid: 2.5.4.3
+                    value: www.example.com
+                subject_alt_name:
+                  - name: DNS
+                    value: www.example.com
+                key_size: 4096
+      rescue:
+        - name: Abort test if certmonger is not supported
+          vars:
+            version_error: >-
+              certmonger version does not support attribute 'key_size'
+          when:
+            - ansible_failed_result is defined
+            - version_error in ansible_failed_result.results[0].msg
+          block:
+            - name: Clear host errors
+              meta: clear_host_errors
+            - name: End play
+              meta: end_play
+
+    - name: Request certificate with key size 3072
+      ansible.builtin.include_role:
+        name: linux-system-roles.certificate
+      vars:
+        certificate_requests:
+          - name: mycert_key_size
+            dns: www.example.com
+            ca: self-sign
+            key_size: 3072
+
+    - name: Fail if certificate was not updated.
+      fail:
+        msg: Certificate was not updated.
+      when:
+        - ansible_failed_result is defined
+        - expected_msg not in ansible_failed_result.results[-1].msg
+      vars:
+        expected_msg: "Certificate requested (updated)"
+
+    - name: Verify each certificate
+      include_tasks: tasks/assert_certificate_parameters.yml
+      loop: "{{ certificates }}"
+      loop_control:
+        loop_var: cert
+      vars:
+        certificates:
+          - path: /etc/pki/tls/certs/mycert_key_size.crt
+            key_path: /etc/pki/tls/private/mycert_key_size.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.com
+            subject_alt_name:
+              - name: DNS
+                value: www.example.com
+            key_size: 3072


### PR DESCRIPTION
**Resolves:** 

When requesting a certificate key size is not evaluated to consider a new certificate has to be requested.

**Result:**

This patch adds 'key_size' to the metadata comparison to determine if a new certificate request must be performed.

**Issue Tracker Tickets (Jira or BZ if any):** [RHBZ#2186057](https://bugzilla.redhat.com/show_bug.cgi?id=2186057)
