### PR TITLE
feat: support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,3 +22,5 @@ exclude_paths:
   - examples/roles/
 mock_roles:
   - linux-system-roles.certificate
+mock_modules:
+  - ansible.utils.update_fact

--- a/.ostree/README.md
+++ b/.ostree/README.md
@@ -1,0 +1,3 @@
+*NOTE*: The `*.txt` files are used by `get_ostree_data.sh` to create the lists
+of packages, and to find other system roles used by this role.  DO NOT use them
+directly.

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -euo pipefail
+
+role_collection_dir="${ROLE_COLLECTION_DIR:-fedora/linux_system_roles}"
+ostree_dir="${OSTREE_DIR:-"$(dirname "$(realpath "$0")")"}"
+
+if [ -z "${4:-}" ] || [ "${1:-}" = help ] || [ "${1:-}" = -h ]; then
+    cat <<EOF
+Usage: $0 packages [runtime|testing] DISTRO-MAJOR[.MINOR] [json|yaml|raw|toml]
+The script will use the packages and roles files in $ostree_dir to
+construct the list of packages needed to build the ostree image.  The script
+will output the list of packages in the given format
+- json is a JSON list like ["pkg1","pkg2",....,"pkgN"]
+- yaml is the YAML list format
+- raw is the list of packages, one per line
+- toml is a list of [[packages]] elements as in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line
+The DISTRO-MAJOR.MINOR is the same format used by Ansible for distribution e.g. CentOS-8, RedHat-8.9, etc.
+EOF
+    exit 1
+fi
+category="$1"
+pkgtype="$2"
+distro_ver="$3"
+format="$4"
+pkgtypes=("$pkgtype")
+if [ "$pkgtype" = testing ]; then
+    pkgtypes+=(runtime)
+fi
+
+get_rolepath() {
+    local ostree_dir role rolesdir
+    ostree_dir="$1"
+    role="$2"
+    rolesdir="$(dirname "$(dirname "$ostree_dir")")/$role/.ostree"
+    if [ -d "$rolesdir" ]; then
+        echo "$rolesdir"
+        return 0
+    fi
+    if [ -n "${ANSIBLE_COLLECTIONS_PATHS:-}" ]; then
+        for pth in ${ANSIBLE_COLLECTIONS_PATHS//:/ }; do
+            rolesdir="$pth/ansible_collections/$role_collection_dir/roles/$role/.ostree"
+            if [ -d "$rolesdir" ]; then
+                echo "$rolesdir"
+                return 0
+            fi
+        done
+    fi
+    return 1
+}
+
+get_packages() {
+    local ostree_dir pkgtype pkgfile rolefile
+    ostree_dir="$1"
+    for pkgtype in "${pkgtypes[@]}"; do
+        for suff in "" "-$distro" "-${distro}-${major_ver}" "-${distro}-${ver}"; do
+            pkgfile="$ostree_dir/packages-${pkgtype}${suff}.txt"
+            if [ -f "$pkgfile" ]; then
+                cat "$pkgfile"
+            fi
+        done
+        rolefile="$ostree_dir/roles-${pkgtype}.txt"
+        if [ -f "$rolefile" ]; then
+            local roles role rolepath
+            roles="$(cat "$rolefile")"
+            for role in $roles; do
+                rolepath="$(get_rolepath "$ostree_dir" "$role")"
+                get_packages "$rolepath"
+            done
+        fi
+    done | sort -u
+}
+
+format_packages_json() {
+    local comma pkgs pkg
+    comma=""
+    pkgs="["
+    while read -r pkg; do
+        pkgs="${pkgs}${comma}\"${pkg}\""
+        comma=,
+    done
+    pkgs="${pkgs}]"
+    echo "$pkgs"
+}
+
+format_packages_raw() {
+    cat
+}
+
+format_packages_yaml() {
+    while read -r pkg; do
+        echo "- $pkg"
+    done
+}
+
+format_packages_toml() {
+    while read -r pkg; do
+        echo "[[packages]]"
+        echo "name = \"$pkg\""
+        echo "version = \"*\""
+    done
+}
+
+distro="${distro_ver%%-*}"
+ver="${distro_ver##*-}"
+if [[ "$ver" =~ ^([0-9]*) ]]; then
+    major_ver="${BASH_REMATCH[1]}"
+else
+    echo ERROR: cannot parse major version number from version "$ver"
+    exit 1
+fi
+
+"get_$category" "$ostree_dir" | "format_${category}_$format"

--- a/.ostree/packages-runtime-CentOS-7.txt
+++ b/.ostree/packages-runtime-CentOS-7.txt
@@ -1,0 +1,3 @@
+python-cryptography
+python-dbus
+python-pyasn1

--- a/.ostree/packages-runtime-CentOS-8.txt
+++ b/.ostree/packages-runtime-CentOS-8.txt
@@ -1,0 +1,3 @@
+python3-cryptography
+python3-dbus
+python3-pyasn1

--- a/.ostree/packages-runtime-CentOS-9.txt
+++ b/.ostree/packages-runtime-CentOS-9.txt
@@ -1,0 +1,3 @@
+python3-cryptography
+python3-dbus
+python3-pyasn1

--- a/.ostree/packages-runtime-Fedora.txt
+++ b/.ostree/packages-runtime-Fedora.txt
@@ -1,0 +1,3 @@
+python3-cryptography
+python3-dbus
+python3-pyasn1

--- a/.ostree/packages-runtime-RedHat-7.txt
+++ b/.ostree/packages-runtime-RedHat-7.txt
@@ -1,0 +1,3 @@
+python-cryptography
+python-dbus
+python-pyasn1

--- a/.ostree/packages-runtime-RedHat-8.txt
+++ b/.ostree/packages-runtime-RedHat-8.txt
@@ -1,0 +1,3 @@
+python3-cryptography
+python3-dbus
+python3-pyasn1

--- a/.ostree/packages-runtime-RedHat-9.txt
+++ b/.ostree/packages-runtime-RedHat-9.txt
@@ -1,0 +1,3 @@
+python3-cryptography
+python3-dbus
+python3-pyasn1

--- a/.ostree/packages-runtime.txt
+++ b/.ostree/packages-runtime.txt
@@ -1,0 +1,1 @@
+certmonger

--- a/.ostree/packages-testing-CentOS-7.txt
+++ b/.ostree/packages-testing-CentOS-7.txt
@@ -1,0 +1,1 @@
+python2-cryptography

--- a/.ostree/packages-testing-CentOS-8.txt
+++ b/.ostree/packages-testing-CentOS-8.txt
@@ -1,0 +1,2 @@
+python3-cryptography
+python3-pyasn1

--- a/.ostree/packages-testing-CentOS-9.txt
+++ b/.ostree/packages-testing-CentOS-9.txt
@@ -1,0 +1,2 @@
+python3-cryptography
+python3-pyasn1

--- a/.ostree/packages-testing-Fedora.txt
+++ b/.ostree/packages-testing-Fedora.txt
@@ -1,0 +1,2 @@
+python3-cryptography
+python3-pyasn1

--- a/.ostree/packages-testing-RedHat-7.txt
+++ b/.ostree/packages-testing-RedHat-7.txt
@@ -1,0 +1,1 @@
+python2-cryptography

--- a/.ostree/packages-testing-RedHat-8.txt
+++ b/.ostree/packages-testing-RedHat-8.txt
@@ -1,0 +1,2 @@
+python3-cryptography
+python3-pyasn1

--- a/.ostree/packages-testing-RedHat-9.txt
+++ b/.ostree/packages-testing-RedHat-9.txt
@@ -1,0 +1,2 @@
+python3-cryptography
+python3-pyasn1

--- a/.ostree/packages-testing.txt
+++ b/.ostree/packages-testing.txt
@@ -1,0 +1,2 @@
+hostname
+nss

--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -24,3 +24,4 @@ plugins/modules/certificate_request.py import-3.7!skip
 plugins/modules/certificate_request.py import-3.8!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.11.txt
+++ b/.sanity-ansible-ignore-2.11.txt
@@ -29,3 +29,4 @@ plugins/modules/certificate_request.py import-3.8!skip
 plugins/modules/certificate_request.py import-3.9!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -33,3 +33,4 @@ plugins/modules/certificate_request.py import-3.9!skip
 plugins/modules/certificate_request.py import-3.10!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -33,3 +33,4 @@ plugins/modules/certificate_request.py import-3.9!skip
 plugins/modules/certificate_request.py import-3.10!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -32,3 +32,4 @@ plugins/modules/certificate_request.py import-3.10!skip
 plugins/modules/certificate_request.py import-3.11!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -32,3 +32,4 @@ plugins/modules/certificate_request.py import-3.10!skip
 plugins/modules/certificate_request.py import-3.11!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -25,3 +25,4 @@ plugins/modules/certificate_request.py import-3.7!skip
 plugins/modules/certificate_request.py import-3.8!skip
 plugins/modules/certificate_request.py validate-modules:missing-gplv3-license
 plugins/modules/certificate_request.py validate-modules:import-error
+roles/certificate/.ostree/get_ostree_data.sh shebang!skip

--- a/README-ostree.md
+++ b/README-ostree.md
@@ -1,0 +1,66 @@
+# rpm-ostree
+
+The role supports running on [rpm-ostree](https://coreos.github.io/rpm-ostree/)
+systems. The primary issue is that the `/usr` filesystem is read-only, and the
+role cannot install packages. Instead, it will just verify that the necessary
+packages and any other `/usr` files are pre-installed. The role will change the
+package manager to one that is compatible with `rpm-ostree` systems.
+
+## Building
+
+To build an ostree image for a particular operating system distribution and
+version, use the script `.ostree/get_ostree_data.sh` to get the list of
+packages. If the role uses other system roles, then the script will include the
+packages for the other roles in the list it outputs.  The list of packages will
+be sorted in alphanumeric order.
+
+Usage:
+
+```bash
+.ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
+```
+
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
+and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`RedHat-9.4`
+
+`FORMAT` is one of `toml`, `json`, `yaml`, `raw`
+
+* `toml` - each package in a TOML `[[packages]]` element
+
+```toml
+[[packages]]
+name = "package-a"
+version = "*"
+[[packages]]
+name = "package-b"
+version = "*"
+...
+```
+
+* `yaml` - a YAML list of packages
+
+```yaml
+- package-a
+- package-b
+...
+```
+
+* `json` - a JSON list of packages
+
+```json
+["package-a","package-b",...]
+```
+
+* `raw` - a plain text list of packages, one per line
+
+```bash
+package-a
+package-b
+...
+```
+
+What format you choose depends on which image builder you are using.  For
+example, if you are using something based on
+[osbuild-composer](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line),
+you will probably want to use the `toml` output format.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ and the key in `/etc/pki/tls/private/mycert.key`.
 
 ## Requirements
 
-None
+See below
+
+### Collection requirements
+
+The role requires external collections only for management of `rpm-ostree`
+nodes. Please run the following command to install them if you need to manage
+`rpm-ostree` nodes:
+
+```bash
+ansible-galaxy collection install -vv -r meta/collection-requirements.yml
+```
 
 ## Variables
 
@@ -430,6 +440,10 @@ Note that you can also use UID and GID instead of user and group names.
 ## Compatibility
 
 Currently supports CentOS 7+, RHEL 7+, Fedora. It has been tested with Debian 10.
+
+## rpm-ostree
+
+See README-ostree.md
 
 ## License
 

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: ansible.posix
+  - name: ansible.utils

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,6 +5,24 @@
   when: __certificate_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
+- name: Ensure correct package manager for ostree systems
+  vars:
+    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+    ostree_booted_file: /run/ostree-booted
+  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: "{{ ostree_booted_file }}"
+      register: __ostree_booted_stat
+
+    - name: Set package manager to use for ostree
+      ansible.utils.update_fact:
+        updates:
+          - path: ansible_facts.pkg_mgr
+            value: "{{ ostree_pkg_mgr }}"
+      when: __ostree_booted_stat.stat.exists
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -3,6 +3,24 @@
   set_fact:
     __virtualenv_path: /tmp/certificate-tests-venv
 
+- name: Ensure correct package manager for ostree systems
+  vars:
+    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+    ostree_booted_file: /run/ostree-booted
+  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: "{{ ostree_booted_file }}"
+      register: __ostree_booted_stat
+
+    - name: Set package manager to use for ostree
+      ansible.utils.update_fact:
+        updates:
+          - path: ansible_facts.pkg_mgr
+            value: "{{ ostree_pkg_mgr }}"
+      when: __ostree_booted_stat.stat.exists
+
 - name: Ensure python3 is installed
   package:
     name:

--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -3,6 +3,24 @@
   set_fact:
     __is_beaker_env: "{{ lookup('env', 'BEAKERLIB') | length > 0 }}"
 
+- name: Ensure correct package manager for ostree systems
+  vars:
+    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+    ostree_booted_file: /run/ostree-booted
+  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: "{{ ostree_booted_file }}"
+      register: __ostree_booted_stat
+
+    - name: Set package manager to use for ostree
+      ansible.utils.update_fact:
+        updates:
+          - path: ansible_facts.pkg_mgr
+            value: "{{ ostree_pkg_mgr }}"
+      when: __ostree_booted_stat.stat.exists
+
 - name: Install ansible-freeipa
   package:
     name: ansible-freeipa

--- a/tests/tests_basic_ipa.yml
+++ b/tests/tests_basic_ipa.yml
@@ -1,95 +1,98 @@
 ---
-- name: Install IPA server
+- name: Test using IPA to issue certs
   hosts: all
   gather_facts: true
   become: true
   tags:
     - tests::slow
   tasks:
+    - name: Check if test is supported
+      vars:
+        ostree_booted_file: /run/ostree-booted
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: "{{ ostree_booted_file }}"
+          register: __ostree_booted_stat
+
+        - name: Skip if not supported
+          meta: end_host
+          when: __ostree_booted_stat.stat.exists
+
     - name: Setup IPA
       import_tasks: tasks/setup_ipa.yml
 
-- name: Issue IPA signed certificates
-  hosts: all
-  become: true
-  tags:
-    - tests::slow
-  vars:
-    certificate_requests:
-      - name: mycert_basic_ipa
-        dns: ipaserver.test.local
-        principal: HTTP/ipaserver.test.local@TEST.LOCAL
-        ca: ipa
+    - name: Issue IPA signed certificates
+      include_role:
+        name: linux-system-roles.certificate
+      vars:
+        certificate_requests:
+          - name: mycert_basic_ipa
+            dns: ipaserver.test.local
+            principal: HTTP/ipaserver.test.local@TEST.LOCAL
+            ca: ipa
 
-      - name: groupcert
-        dns: ipaserver.test.local
-        principal: HTTP/ipaserver.test.local@TEST.LOCAL
-        ca: ipa
-        group: ftp
-  roles:
-    - linux-system-roles.certificate
+          - name: groupcert
+            dns: ipaserver.test.local
+            principal: HTTP/ipaserver.test.local@TEST.LOCAL
+            ca: ipa
+            group: ftp
 
-- name: Verify certificates
-  hosts: all
-  become: true
-  tags:
-    - tests::slow
-  vars:
-    certificates:
-      - path: /etc/pki/tls/certs/mycert_basic_ipa.crt
-        key_path: /etc/pki/tls/private/mycert_basic_ipa.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: ipaserver.test.local
-          - name: organizationName
-            oid: 2.5.4.10
-            value: TEST.LOCAL
-        subject_alt_name:
-          - name: DNS
-            value: ipaserver.test.local
-          - name: Universal Principal Name (UPN)
-            oid: 1.3.6.1.4.1.311.20.2.3
-            value: HTTP/ipaserver.test.local@TEST.LOCAL
-          - name: Kerberos principalname
-            oid: 1.3.6.1.5.2.2
-            value: HTTP/ipaserver.test.local@TEST.LOCAL
-        # IPA CA doesn't respect the requested key_usage (and that's ok)
-        key_usage:
-          - digital_signature
-          - content_commitment
-          - key_encipherment
-          - data_encipherment
-
-      - path: /etc/pki/tls/certs/groupcert.crt
-        key_path: /etc/pki/tls/private/groupcert.key
-        owner: root
-        group: ftp
-        mode: "0640"
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: ipaserver.test.local
-          - name: organizationName
-            oid: 2.5.4.10
-            value: TEST.LOCAL
-        subject_alt_name:
-          - name: DNS
-            value: ipaserver.test.local
-          - name: Universal Principal Name (UPN)
-            oid: 1.3.6.1.4.1.311.20.2.3
-            value: HTTP/ipaserver.test.local@TEST.LOCAL
-          - name: Kerberos principalname
-            oid: 1.3.6.1.5.2.2
-            value: HTTP/ipaserver.test.local@TEST.LOCAL
-        key_usage:
-          - digital_signature
-          - content_commitment
-          - key_encipherment
-          - data_encipherment
-  tasks:
-    - name: Verify each certificate
+    - name: Verify certificates
       include_tasks: tasks/assert_certificate_parameters.yml
       loop: "{{ certificates }}"
       loop_control:
         loop_var: cert
+      vars:
+        certificates:
+          - path: /etc/pki/tls/certs/mycert_basic_ipa.crt
+            key_path: /etc/pki/tls/private/mycert_basic_ipa.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: ipaserver.test.local
+              - name: organizationName
+                oid: 2.5.4.10
+                value: TEST.LOCAL
+            subject_alt_name:
+              - name: DNS
+                value: ipaserver.test.local
+              - name: Universal Principal Name (UPN)
+                oid: 1.3.6.1.4.1.311.20.2.3
+                value: HTTP/ipaserver.test.local@TEST.LOCAL
+              - name: Kerberos principalname
+                oid: 1.3.6.1.5.2.2
+                value: HTTP/ipaserver.test.local@TEST.LOCAL
+            # IPA CA doesn't respect the requested key_usage (and that's ok)
+            key_usage:
+              - digital_signature
+              - content_commitment
+              - key_encipherment
+              - data_encipherment
+
+          - path: /etc/pki/tls/certs/groupcert.crt
+            key_path: /etc/pki/tls/private/groupcert.key
+            owner: root
+            group: ftp
+            mode: "0640"
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: ipaserver.test.local
+              - name: organizationName
+                oid: 2.5.4.10
+                value: TEST.LOCAL
+            subject_alt_name:
+              - name: DNS
+                value: ipaserver.test.local
+              - name: Universal Principal Name (UPN)
+                oid: 1.3.6.1.4.1.311.20.2.3
+                value: HTTP/ipaserver.test.local@TEST.LOCAL
+              - name: Kerberos principalname
+                oid: 1.3.6.1.5.2.2
+                value: HTTP/ipaserver.test.local@TEST.LOCAL
+            key_usage:
+              - digital_signature
+              - content_commitment
+              - key_encipherment
+              - data_encipherment


### PR DESCRIPTION
Feature: Allow running and testing the role with ostree managed nodes.

Reason: We have users who want to use the role to manage ostree
systems.

Result: Users can use the role to manage ostree managed nodes.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
