### PR TITLE
ci: Add support for SUSE ALP-Dolomite

### DIFF
--- a/.ostree/packages-runtime-SUSE-ALP.txt
+++ b/.ostree/packages-runtime-SUSE-ALP.txt
@@ -1,0 +1,3 @@
+python311-dbus-python
+python311-cryptography
+python3-pyasn1

--- a/.ostree/packages-testing-SUSE-ALP.txt
+++ b/.ostree/packages-testing-SUSE-ALP.txt
@@ -1,0 +1,2 @@
+python311-dbus-python
+python311-cryptography

--- a/vars/ALP-Dolomite.yml
+++ b/vars/ALP-Dolomite.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with ALP-Dolomite specific values.
+
+__certificate_default_directory: /etc/ssl
+
+__certificate_packages:
+  - python311-cryptography
+  - python311-dbus-python
+  - python3-pyasn1


### PR DESCRIPTION
Enhancement: Add support for SUSE ALP-Dolomite in the certificate Ansible role.

Reason: This enhancement aims to introduce compatibility by adjusting file paths, package dependencies

Result: Updated the certificate role for SUSE ALP-Dolomite

Issue Tracker Tickets (Jira or BZ if any):na
