### PR TITLE
ciadd SLES vars

### DIFF
--- a/.ostree/packages-testing-SUSE-ALP.txt
+++ b/.ostree/packages-testing-SUSE-ALP.txt
@@ -1,2 +1,0 @@
-python311-dbus-python
-python311-cryptography

--- a/vars/SLES.yml
+++ b/vars/SLES.yml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
 ---
-# Put internal variables here with ALP-Dolomite specific values.
+# Put internal variables here with SLES specific values.
 
 __certificate_default_directory: /etc/ssl
 
 __certificate_packages:
-  - python311-cryptography
-  - python311-dbus-python
+  - python3-cryptography
+  - python3-dbus-python
   - python3-pyasn1


### PR DESCRIPTION
Enhancement: Add SLES vars file to support SLES systems. Remove redundant ALP-Dolomite references.

Reason: Ensure proper handling of SLES-specific paths, package names.

Result: Correct paths and package names are used for SLES.

Issue Tracker Tickets (Jira or BZ if any):na
