### PR TITLE
ci: Add vars for SLES_SAP

### DIFF
--- a/vars/SLES_15.yml
+++ b/vars/SLES_15.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-# Put internal variables here with SLES specific values.
+# Put internal variables here with SLES_15 specific values.
 
 __certificate_default_directory: /etc/ssl
 

--- a/vars/SLES_16.yml
+++ b/vars/SLES_16.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with SLES_16 specific values.
+
+__certificate_default_directory: /etc/ssl
+
+__certificate_packages:
+  - python311-cryptography
+  - python311-dbus-python
+  - python311-pyasn1

--- a/vars/SLES_SAP_15.yml
+++ b/vars/SLES_SAP_15.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with SLES_SAP_15 specific values.
+
+__certificate_default_directory: /etc/ssl
+
+__certificate_packages:
+  - python3-cryptography
+  - python3-dbus-python
+  - python3-pyasn1

--- a/vars/SLES_SAP_16.yml
+++ b/vars/SLES_SAP_16.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with SLES_SAP_16 specific values.
+
+__certificate_default_directory: /etc/ssl
+
+__certificate_packages:
+  - python311-cryptography
+  - python311-dbus-python
+  - python311-pyasn1


### PR DESCRIPTION
Enhancement: Add SLES_SAP vars file to support SLES_SAP systems 15 and 16.
Reason:  Ensure proper handling package names for particular SLES versions.
Result: Correct paths and package names and versions are used for SLES15/16 and SLES_SAP15/16.

Issue Tracker Tickets (Jira or BZ if any): na
