### PR TITLE
fix: update python package dependencies for SLE 16

### DIFF
--- a/vars/SLES_16.yml
+++ b/vars/SLES_16.yml
@@ -5,6 +5,6 @@
 __certificate_default_directory: /etc/ssl
 
 __certificate_packages:
-  - python311-cryptography
-  - python311-dbus-python
-  - python311-pyasn1
+  - python313-cryptography
+  - python313-dbus-python
+  - python313-pyasn1

--- a/vars/SLES_SAP_16.yml
+++ b/vars/SLES_SAP_16.yml
@@ -5,6 +5,6 @@
 __certificate_default_directory: /etc/ssl
 
 __certificate_packages:
-  - python311-cryptography
-  - python311-dbus-python
-  - python311-pyasn1
+  - python313-cryptography
+  - python313-dbus-python
+  - python313-pyasn1


### PR DESCRIPTION
Enhancement: Replaced `python311-*` packages with their `python313-*` equivalents.

Reason: Fails missing 3.11 packages, due to python version upgrade.

Result: Uses updated python313 packages.

Issue Tracker Tickets (Jira or BZ if any): na

## Summary by Sourcery

Enhancements:
- Replace python311-cryptography, python311-dbus-python, and python311-pyasn1 with their python313 equivalents in SLES_16 and SLES_SAP_16