### PR TITLE
refactor: Ansible 2.19 support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,28 +11,19 @@
 
 - name: Install and configure required providers
   vars:
-    __certificate_providers: |
-      {% set unique_providers = [] %}
-      {% for item in certificate_requests %}
-      {%   set _ = unique_providers.append(
-             item.provider |
-             d(__certificate_provider_default)
-           ) %}
-      {% endfor %}
-      {{ unique_providers | unique }}
+    __certificate_providers: "{{ (certificate_requests | selectattr('provider', 'defined') | map(attribute='provider') | list) +
+      [__certificate_provider_default] | unique | list }}"
   block:
     - name: Ensure provider packages are installed
       package:
-        name: |
-          {{ __certificate_provider_vars[__certificate_provider].packages }}
+        name: "{{ __certificate_provider_vars[__certificate_provider].packages }}"
         state: present
         use: "{{ (__certificate_is_ostree | d(false)) |
           ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
       loop: "{{ __certificate_providers }}"
       loop_control:
         loop_var: __certificate_provider
-      when: |
-        __certificate_provider_vars[__certificate_provider].packages is defined
+      when: __certificate_provider_vars[__certificate_provider].packages is defined
 
     - name: Ensure pre-scripts hooks directory exists
       file:
@@ -56,9 +47,7 @@
       loop: "{{ __certificate_providers }}"
       loop_control:
         loop_var: __certificate_provider
-      when: |
-        __certificate_provider_vars[__certificate_provider].config_dir
-        is defined
+      when: __certificate_provider_vars[__certificate_provider].config_dir is defined
 
     - name: Ensure post-scripts hooks directory exists
       file:
@@ -82,24 +71,20 @@
       loop: "{{ __certificate_providers }}"
       loop_control:
         loop_var: __certificate_provider
-      when: |
-        __certificate_provider_vars[__certificate_provider].config_dir
-        is defined
+      when: __certificate_provider_vars[__certificate_provider].config_dir is defined
 
     # While most Linux system roles have a list of services
     #   this role doesn't need it. In fact some providers
     #   won't have any service at all.
     - name: Ensure provider service is running
       service:
-        name: >-
-          {{ __certificate_provider_vars[__certificate_provider].service }}
+        name: "{{ __certificate_provider_vars[__certificate_provider].service }}"
         state: started
         enabled: true
       loop: "{{ __certificate_providers }}"
       loop_control:
         loop_var: __certificate_provider
-      when:
-        __certificate_provider_vars[__certificate_provider].service is defined
+      when: __certificate_provider_vars[__certificate_provider].service is defined
 
 - name: Ensure certificate requests
   certificate_request:
@@ -165,21 +150,26 @@
           if item[0] == 'key' else
           __ca_dir ~ '/' ~ item[1].name ~ '.crt' }}"
 
+    - name: Reset certificate_test_certs
+      set_fact:
+        certificate_test_certs: {}
+
     - name: Create return data
       set_fact:
-        certificate_test_certs: |
-          {% set rv = {} %}
-          {% for ii in __certificate_test_data.results %}
-          {%   set name = ii.item[1].name %}
-          {%   set dct = rv.setdefault(name, {}) %}
-          {%   set key1 = ii.item[0] %}
-          {%   set val1 = ii.source %}
-          {%   set key2 = ii.item[0] ~ '_content' %}
-          {%   set val2 = ii.content | b64decode %}
-          {%   set _ = dct.__setitem__(key1, val1) %}
-          {%   set _ = dct.__setitem__(key2, val2) %}
-          {% endfor %}
-          {{ rv }}
+        certificate_test_certs: "{{ certificate_test_certs | combine({cert_name: cert_data}) }}"
+      loop: "{{ __certificate_test_data.results | map(attribute='item.1.name') | unique | list }}"
+      loop_control:
+        loop_var: cert_name
+      vars:
+        name_match: "{{ '^' ~ cert_name ~ '$' }}"
+        cert_data: "{{ dict((file_keys + content_keys) | zip(file_vals + content_vals)) }}"
+        file_keys: "{{ __certificate_test_data.results | selectattr('item.1.name', 'match', name_match) |
+          map(attribute='item.0') | list }}"
+        content_keys: "{{ file_keys | map('regex_replace', '$', '_content') | list }}"
+        file_vals: "{{ __certificate_test_data.results | selectattr('item.1.name', 'match', name_match) |
+          map(attribute='source') | list }}"
+        content_vals: "{{ __certificate_test_data.results | selectattr('item.1.name', 'match', name_match) |
+          map(attribute='content') | map('b64decode') | list }}"
 
     - name: Stop tracking certificates
       command: getcert stop-tracking -f {{ item.cert }}

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -8,8 +8,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __lsr_ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ __content.content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __lsr_ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_test_mode.yml
+++ b/tests/tests_test_mode.yml
@@ -1,0 +1,28 @@
+---
+- name: Test test mode
+  hosts: all
+  vars:
+    __test_cert_name1: lsr_cert_test_mode_1
+    __test_cert_name2: lsr_cert_test_mode_2
+    certificate_requests:
+      - name: "{{ __test_cert_name1 }}"
+        dns: ["localhost"]
+        ca: self-sign
+      - name: "{{ __test_cert_name2 }}"
+        dns: ["localhost"]
+        ca: self-sign
+    certificate_test_mode: true
+    certificate_test_remove_files: true
+  tasks:
+    - name: Run the role in test mode
+      include_role:
+        name: linux-system-roles.certificate
+
+    - name: Verify test data
+      assert:
+        that:
+          - certificate_test_certs[item.0][item.1] | length > 10
+          - certificate_test_certs[item.0][item.1 ~ "_content"] | length > 100
+      loop: "{{ [__test_cert_name1, __test_cert_name2] | product(key_names) | list }}"
+      vars:
+        key_names: [ca, cert, key]


### PR DESCRIPTION
Ansible 2.19 introduces some big changes
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_core_2.19.html

One big change is that data structures are no longer mutable by the use of python
methods such as `__setitem__`, `setdefault`, `update`, etc.  in Jinja constructs.
Instead, items must use filters or other Jinja operations.

One common idiom is to mutate each element in a list.  Since we cannot do this
"in-place" anymore, a common way to do this is:

```yaml
- name: Construct a new list from an existing list and mutate each element
  set_fact:
    __new_list: "{{ __new_list | d([]) + [mutated_item] }}"
  loop: "{{ old_list }}"
  mutated_item: "{{ some value based on item from old list }}"

- name: Reset original old list
  set_fact:
    old_list: "{{ __new_list }}"
```

Similarly with `dict` items:

```yaml
- name: Construct a new dict from an existing dict and mutate each element
  set_fact:
    __new_dict: "{{ __new_dict | d({}) | combine(mutated_item) }}"
  loop: "{{ old_dict | dict2items }}"
  mutated_item: "{{ {item.key: mutation of item.value} }}"

- name: Reset original old dict
  set_fact:
    old_dict: "{{ __new_dict }}"
```

Another big change is that a boolean expression in a `when` or similar construct
must be converted to a boolean - we cannot rely on the implicit evaluation in
a boolean context.  For example, if `var` is some iterable, like a `dict`, `list`,
or `string`, you used to be able to evaluate an empty value in a boolean context:

```yaml
when: var  # do this only if var is not empty
```

You now have to explicitly test for empty using `length`:

```yaml
when: var | length > 0  # do this only if var is not empty
```

Similarly for `int` values - you cannot rely on `0` being evaluated as false
and non-zero true - you must explicitly compare the values with `==` or `!=`

These are the biggest changes.  See the porting guide for others.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Support Ansible 2.19 by refactoring Jinja data manipulations to use filter-based constructions for immutable structures, simplify task expressions, and enhance test coverage for the test mode.

New Features:
- Add a full-role playbook to validate certificate_test_mode and assert generated test data.

Enhancements:
- Refactor certificate_providers and related loops to build lists and dicts using filters instead of mutable Jinja operations.
- Simplify package, service, and file tasks to use inline Jinja expressions and streamlined when conditions.
- Restructure certificate_test_certs assembly by initializing state and constructing nested dictionaries via loops and combine filters.

Tests:
- Update header assertion to use __lsr_ansible_managed variable.
- Add end-to-end test in tests/tests_test_mode.yml to verify certificate_test_mode behavior.