### PR TITLE
feat: Support this role in system container environments

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
     - centos
     - certificate
     - certmonger
+    - container
     - el7
     - el8
     - el9

--- a/tests/tests_basic_ipa.yml
+++ b/tests/tests_basic_ipa.yml
@@ -5,6 +5,8 @@
   become: true
   tags:
     - tests::slow
+    # IPA setup does not work in system containers
+    - tests::reboot
   tasks:
     - name: Check if test is supported
       vars:


### PR DESCRIPTION
Feature: Support running the ssh role in system container environments.

Reason: It's also desirable to run roles in system containers. It also eases development and testing.

Result: These flags enable running the podman system container scenarios in CI.

tests_basic_ipa.yml does not work there, as at least our FreeIPA setup script requires a full VM. So skip it there. All other tests work.
