### PR TITLE
docs(changelog): version 1.3.12 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+[1.3.12] - 2025-06-16
+--------------------
+
+### Other Changes
+
+- ci: Add support for bootc end-to-end validation tests (#272)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#273)
+- refactor: Ansible 2.19 support (#274)
+
 [1.3.11] - 2025-05-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.3.12

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation for version 1.3.12, adding CI improvements and Ansible 2.19 support

Enhancements:
- Refactor code to support Ansible 2.19

CI:
- Add support for bootc end-to-end validation tests
- Use Ansible 2.19 for Fedora 42 testing and enable Python 3.13 support

Documentation:
- Add changelog entry and update README.html for v1.3.12