### PR TITLE
feat: Support this role in container builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Alternative Names (SAN).
 | auto_renew           | Indicates if the certificate should be renewed automatically before it expires.                   | bool        | no       | yes                     |
 | owner                | User name (or user id) for the certificate and key files.                                         | str         | no       | *User running Ansible*  |
 | group                | Group name (or group id) for the certificate and key files.                                       | str         | no       | *Group running Ansible* |
-| mode                 | The file system permissions for the certificate and key files.                                    | raw         | no       | -                       |
+| mode                 | The file system permissions for the certificate and key files.                                    | str or octal| no       | -                       |
 | key\_size            | Generate keys with a specific keysize in bits.                                                    | int         | no       | 2048 - See [key\_size](#key_size) |
 | common\_name         | Common Name requested for the certificate subject.                                                | str         | no       | See [common\_name](#common_name)  |
 | country              | Country code requested for the certificate subject.                                               | str         | no       | -                       |

--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ Alternative Names (SAN).
 | auto_renew           | Indicates if the certificate should be renewed automatically before it expires.                   | bool        | no       | yes                     |
 | owner                | User name (or user id) for the certificate and key files.                                         | str         | no       | *User running Ansible*  |
 | group                | Group name (or group id) for the certificate and key files.                                       | str         | no       | *Group running Ansible* |
-| mode                     | The file system permissions for the certificate and key files.
-  | raw         | no       | -                       |
+| mode                 | The file system permissions for the certificate and key files.                                    | raw         | no       | -                       |
 | key\_size            | Generate keys with a specific keysize in bits.                                                    | int         | no       | 2048 - See [key\_size](#key_size) |
 | common\_name         | Common Name requested for the certificate subject.                                                | str         | no       | See [common\_name](#common_name)  |
 | country              | Country code requested for the certificate subject.                                               | str         | no       | -                       |

--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -178,6 +178,13 @@ options:
       - as rendered by the template module
     type: str
     required: true
+  booted:
+    description:
+      - The role is run in a booted system and can directly talk to
+        services. If false, the certificate generation will be
+        deferred to the first boot.
+    type: bool
+    default: true
 
 author:
   - Sergio Oliveira Campos (@seocam)
@@ -384,6 +391,7 @@ class CertificateRequestModule(AnsibleModule):
             run_before=dict(type="str"),
             run_after=dict(type="str"),
             __header=dict(type="str", required=True),
+            booted=dict(type="bool", required=False, default=True),
         )
 
     @property

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
     - centos
     - certificate
     - certmonger
+    - containerbuild
     - el7
     - el8
     - el9

--- a/module_utils/certificate_lsr/providers/base.py
+++ b/module_utils/certificate_lsr/providers/base.py
@@ -651,12 +651,17 @@ class CertificateRequestBaseProvider:
             msg=self.message,
         )
 
-    def _set_user_and_group_if_different(self):
+    def _get_permissions(self):
         owner = self.module.params.get("owner")
         group = self.module.params.get("group")
         mode = self.module.params.get("mode")
         if group and not mode:
             mode = "0640"
+
+        return (owner, group, mode)
+
+    def _set_user_and_group_if_different(self):
+        (owner, group, mode) = self._get_permissions()
 
         if not any([owner, group, mode]):
             return False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
     - name: Ensure provider service is running
       service:
         name: "{{ __certificate_provider_vars[__certificate_provider].service }}"
-        state: started
+        state: "{{ 'started' if __certificate_is_booted else omit }}"
         enabled: true
       loop: "{{ __certificate_providers }}"
       loop_control:
@@ -119,6 +119,7 @@
     run_after: "{{ item.run_after | default(omit) }}"
     ca: "{{ item.ca | default(omit) }}"
     __header: "{{ __lsr_ansible_managed }}"
+    booted: "{{ __certificate_is_booted }}"
   loop: "{{ certificate_requests }}"
   vars:
     __lsr_ansible_managed: "{{
@@ -138,6 +139,11 @@
     __key_dir: "{{ __certificate_default_directory ~ '/private' }}"
     __ca_dir: "{{ __certificate_default_directory ~ '/certs' }}"
   block:
+    - name: Check if test mode is supported
+      fail:
+        msg: "Test mode is not supported in non-booted mode."
+      when: not __certificate_is_booted
+
     - name: Slurp the contents of the files
       slurp:
         path: "{{ __file }}"

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -17,6 +17,27 @@
       set_fact:
         __certificate_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is booted with systemd
+  when: __certificate_is_booted is not defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      check_mode: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __certificate_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -1,166 +1,209 @@
 ---
-- name: Set virtualenv_path
-  set_fact:
-    __virtualenv_path: /tmp/certificate-tests-venv
-
-- name: Determine if system is ostree and set flag
-  when: not __certificate_is_ostree is defined
+- name: Verify certificate in running systems
+  when: ansible_connection != "buildah"
   block:
-    - name: Check if system is ostree
-      stat:
-        path: /run/ostree-booted
-      register: __ostree_booted_stat
-
-    - name: Set flag to indicate system is ostree
+    - name: Set virtualenv_path
       set_fact:
-        __certificate_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+        __virtualenv_path: /tmp/certificate-tests-venv
 
-- name: Ensure python2 is installed
-  package:
-    name:
-      - python2-cryptography
-      - python2-cryptography
-    use: "{{ (__certificate_is_ostree | d(false)) |
-      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when:
-    - ansible_distribution_major_version == "7"
-    - ansible_os_family == "RedHat"
+    - name: Determine if system is ostree and set flag
+      when: not __certificate_is_ostree is defined
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
 
-- name: Ensure python3 is installed
-  package:
-    name:
-      - python3-cryptography
-      - python3-pyasn1
-    use: "{{ (__certificate_is_ostree | d(false)) |
-      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when:
-    - ansible_distribution_major_version != "7"
-    - ansible_os_family == "RedHat"
+        - name: Set flag to indicate system is ostree
+          set_fact:
+            __certificate_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
-- name: Retrieve certificate file stats
-  stat:
-    path: "{{ cert['path'] }}"
-  register: result
+    - name: Ensure python2 is installed
+      package:
+        name:
+          - python2-cryptography
+          - python2-cryptography
+        use: "{{ (__certificate_is_ostree | d(false)) |
+          ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      when:
+        - ansible_distribution_major_version == "7"
+        - ansible_os_family == "RedHat"
 
-- name: Verify if certificate file exists
-  assert:
-    that:
-      - result.stat.exists
-    fail_msg: "Certificate file '{{ cert['path'] }}' does not exist."
+    - name: Ensure python3 is installed
+      package:
+        name:
+          - python3-cryptography
+          - python3-pyasn1
+        use: "{{ (__certificate_is_ostree | d(false)) |
+          ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      when:
+        - ansible_distribution_major_version != "7"
+        - ansible_os_family == "RedHat"
 
-- name: Verify certificate file owner and group
-  assert:
-    that:
-      - (cert['owner'] | default('root')) in
-        [result.stat.pw_name, result.stat.uid]
-      - (cert['group'] | default('root')) in
-        [result.stat.gr_name, result.stat.gid]
-    fail_msg: >-
-      {{ result.stat.pw_name }}:{{ result.stat.gr_name }} !=
-      {{ cert['owner'] | default('root') }}:
-      {{ cert['group'] | default('root') }}
+    - name: Retrieve certificate file stats
+      stat:
+        path: "{{ cert['path'] }}"
+      register: result
 
-- name: Verify certificate permissions
-  assert:
-    that:
-      - result.stat.mode == (cert['mode'] | default('0600'))
-    fail_msg: "{{ result.stat.mode }} != {{ cert['mode'] | default('0600') }}"
+    - name: Verify if certificate file exists
+      assert:
+        that:
+          - result.stat.exists
+        fail_msg: "Certificate file '{{ cert['path'] }}' does not exist."
 
-- name: Retrieve key file stats
-  stat:
-    path: "{{ cert['key_path'] }}"
-  register: result
+    - name: Verify certificate file owner and group
+      assert:
+        that:
+          - (cert['owner'] | default('root')) in
+            [result.stat.pw_name, result.stat.uid]
+          - (cert['group'] | default('root')) in
+            [result.stat.gr_name, result.stat.gid]
+        fail_msg: >-
+          {{ result.stat.pw_name }}:{{ result.stat.gr_name }} !=
+          {{ cert['owner'] | default('root') }}:
+          {{ cert['group'] | default('root') }}
 
-- name: Verify if key file exists
-  assert:
-    that:
-      - result.stat.exists
-    fail_msg: "Key file '{{ cert['key_path'] }}' does not exist."
+    - name: Verify certificate permissions
+      assert:
+        that:
+          - result.stat.mode == (cert['mode'] | default('0600'))
+        fail_msg: "{{ result.stat.mode }} != {{ cert['mode'] | default('0600') }}"
 
-- name: Verify key file owner and group
-  assert:
-    that:
-      - (cert['owner'] | default('root')) in
-        [result.stat.pw_name, result.stat.uid]
-      - (cert['group'] | default('root')) in
-        [result.stat.gr_name, result.stat.gid]
-    fail_msg: >-
-      {{ result.stat.pw_name }}:{{ result.stat.gr_name }} !=
-      {{ cert['owner'] | default('root') }}:
-      {{ cert['group'] | default('root') }}
+    - name: Retrieve key file stats
+      stat:
+        path: "{{ cert['key_path'] }}"
+      register: result
 
-- name: Parse certificate
-  certtojson:
-    filename: "{{ cert['path'] }}"
-  register: certificate_data
-  changed_when: false
+    - name: Verify if key file exists
+      assert:
+        that:
+          - result.stat.exists
+        fail_msg: "Key file '{{ cert['key_path'] }}' does not exist."
 
-- name: Load certificate YAML to cert_issued variable
-  set_fact:
-    cert_issued: "{{ certificate_data.certificate }}"
+    - name: Verify key file owner and group
+      assert:
+        that:
+          - (cert['owner'] | default('root')) in
+            [result.stat.pw_name, result.stat.uid]
+          - (cert['group'] | default('root')) in
+            [result.stat.gr_name, result.stat.gid]
+        fail_msg: >-
+          {{ result.stat.pw_name }}:{{ result.stat.gr_name }} !=
+          {{ cert['owner'] | default('root') }}:
+          {{ cert['group'] | default('root') }}
 
-- name: Verify certificate subject
-  assert:
-    that:
-      - cert.subject | sort(attribute="name") ==
-        cert_issued.subject | sort(attribute="name")
-    fail_msg: >-
-      {{ cert.subject | sort(attribute="name") }} !=
-      {{ cert_issued.subject | sort(attribute="name") }}
+    - name: Parse certificate
+      certtojson:
+        filename: "{{ cert['path'] }}"
+      register: certificate_data
+      changed_when: false
 
-- name: Verify certificate SAN
-  assert:
-    that:
-      - cert.subject_alt_name ==
-        cert_issued.extensions.subjectAltName.value
-    fail_msg: >-
-      {{ cert.subject_alt_name }} !=
-      {{ cert_issued.extensions.subjectAltName.value }}
+    - name: Load certificate YAML to cert_issued variable
+      set_fact:
+        cert_issued: "{{ certificate_data.certificate }}"
 
-- name: Verify key size
-  assert:
-    that:
-      - cert.key_size | default(2048) == cert_issued.key_size
-    fail_msg: >-
-      {{ cert.key_size | default(2048) }} != {{ cert_issued.key_size }}
+    - name: Verify certificate subject
+      assert:
+        that:
+          - cert.subject | sort(attribute="name") ==
+            cert_issued.subject | sort(attribute="name")
+        fail_msg: >-
+          {{ cert.subject | sort(attribute="name") }} !=
+          {{ cert_issued.subject | sort(attribute="name") }}
 
-- name: Verify certificate Key Usage
-  vars:
-    default_ku:
-      - digital_signature
-      - key_encipherment
-    expected: "{{ cert.key_usage | d(default_ku) | sort }}"
-    actual: "{{ cert_issued.extensions.keyUsage.value | sort }}"
-  assert:
-    that: expected == actual
-    fail_msg: expected value {{ expected }} != {{ actual }}
+    - name: Verify certificate SAN
+      assert:
+        that:
+          - cert.subject_alt_name ==
+            cert_issued.extensions.subjectAltName.value
+        fail_msg: >-
+          {{ cert.subject_alt_name }} !=
+          {{ cert_issued.extensions.subjectAltName.value }}
 
-- name: Verify certificate Extended Key Usage
-  vars:
-    default_eku:
-      - name: id-kp-serverAuth
-        oid: 1.3.6.1.5.5.7.3.1
-      - name: id-kp-clientAuth
-        oid: 1.3.6.1.5.5.7.3.2
-    expected: "{{ cert.extended_key_usage | d(default_eku) }}"
-    actual: "{{ cert_issued.extensions.extendedKeyUsage.value }}"
-  assert:
-    that: expected == actual
-    fail_msg: expected value {{ expected }} != {{ actual }}
+    - name: Verify key size
+      assert:
+        that:
+          - cert.key_size | default(2048) == cert_issued.key_size
+        fail_msg: >-
+          {{ cert.key_size | default(2048) }} != {{ cert_issued.key_size }}
 
-- name: Retrieve auto-renew flag
-  shell: >-
-    set -euo pipefail;
-    getcert list -f {{ cert['path'] }} |
-    grep 'auto-renew' |
-    sed 's/^\s\+auto-renew: //g'
-  register: result
-  changed_when: false
+    - name: Verify certificate Key Usage
+      vars:
+        default_ku:
+          - digital_signature
+          - key_encipherment
+        expected: "{{ cert.key_usage | d(default_ku) | sort }}"
+        actual: "{{ cert_issued.extensions.keyUsage.value | sort }}"
+      assert:
+        that: expected == actual
+        fail_msg: expected value {{ expected }} != {{ actual }}
 
-- name: Verify certificate auto-renew flag
-  assert:
-    that:
-      - (cert['auto_renew'] | default('yes') | bool) == (result.stdout | bool)
-    fail_msg: >-
-      {{ cert['auto_renew'] | default('yes') | bool }} !=
-      {{ result.stdout | bool }}
+    - name: Verify certificate Extended Key Usage
+      vars:
+        default_eku:
+          - name: id-kp-serverAuth
+            oid: 1.3.6.1.5.5.7.3.1
+          - name: id-kp-clientAuth
+            oid: 1.3.6.1.5.5.7.3.2
+        expected: "{{ cert.extended_key_usage | d(default_eku) }}"
+        actual: "{{ cert_issued.extensions.extendedKeyUsage.value }}"
+      assert:
+        that: expected == actual
+        fail_msg: expected value {{ expected }} != {{ actual }}
+
+    - name: Retrieve auto-renew flag
+      shell: >-
+        set -euo pipefail;
+        getcert list -f {{ cert['path'] }} |
+        grep 'auto-renew' |
+        sed 's/^\s\+auto-renew: //g'
+      register: result
+      changed_when: false
+
+    - name: Verify certificate auto-renew flag
+      assert:
+        that:
+          - (cert['auto_renew'] | default('yes') | bool) == (result.stdout | bool)
+        fail_msg: >-
+          {{ cert['auto_renew'] | default('yes') | bool }} !=
+          {{ result.stdout | bool }}
+
+    - name: Stat commands file
+      stat:
+        path: /var/lib/certmonger/system-roles-create.commands
+      register: commands_file_stat
+
+    - name: Assert that commands file got removed
+      assert:
+        that:
+          - not commands_file_stat.stat.exists
+
+- name: Verify certificate in container builds
+  when: ansible_connection == "buildah"
+  block:
+    - name: Stat first-boot unit file
+      stat:
+        path: /etc/systemd/system/system-roles-certmonger-create.service
+      register: first_boot_unit_stat
+
+    - name: Assert presence of first-boot unit
+      assert:
+        that:
+          - first_boot_unit_stat.stat.exists
+
+    - name: Assert that first-boot unit is enabled
+      # noqa command-instead-of-module
+      command: systemctl is-enabled system-roles-certmonger-create.service
+      register: first_boot_unit_enabled
+      changed_when: false
+      failed_when: first_boot_unit_enabled.stdout != "enabled"
+
+    - name: Stat commands file
+      stat:
+        path: /var/lib/certmonger/system-roles-create.commands
+      register: commands_file_stat
+
+    - name: Assert that commands file exists
+      assert:
+        that:
+          - commands_file_stat.stat.exists

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -15,7 +15,7 @@
       set_fact:
         __certificate_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
-- name: Ensure python3 is installed
+- name: Ensure python2 is installed
   package:
     name:
       - python2-cryptography

--- a/tests/tests_basic_ipa.yml
+++ b/tests/tests_basic_ipa.yml
@@ -5,6 +5,9 @@
   become: true
   tags:
     - tests::slow
+    # can't run IPA in a buildah system
+    # this is a test restriction, not a role restriction
+    - tests::booted
   tasks:
     - name: Check if test is supported
       vars:

--- a/tests/tests_fs_attrs.yml
+++ b/tests/tests_fs_attrs.yml
@@ -6,10 +6,13 @@
       user:
         name: user1
         uid: 1040
+      when: not __bootc_validation | d(false)
+
     - name: Ensure group "somegroup" exists
       group:
         name: somegroup
         gid: 1041
+      when: not __bootc_validation | d(false)
 
     - name: Issue certificate setting user/group
       include_role:
@@ -26,6 +29,7 @@
             owner: 1040
             group: 1041
             ca: self-sign
+      when: not __bootc_validation | d(false)
 
     - name: Verify each user/group certificate
       include_tasks: tasks/assert_certificate_parameters.yml
@@ -76,6 +80,14 @@
             # yamllint disable rule:octal-values
             mode: 0o600
             ca: self-sign
+      when: not __bootc_validation | d(false)
+
+    - name: Create QEMU deployment during bootc end-to-end test
+      delegate_to: localhost
+      become: false
+      command: "{{ lsr_scriptdir }}/bootc-buildah-qcow.sh {{ ansible_host }}"
+      changed_when: true
+      when: ansible_connection == "buildah"
 
     - name: Verify each fs_attrs_mode certificate
       include_tasks: tasks/assert_certificate_parameters.yml

--- a/tests/tests_fs_attrs.yml
+++ b/tests/tests_fs_attrs.yml
@@ -72,7 +72,9 @@
             ca: self-sign
           - name: certid_mode
             dns: www.example.com
-            mode: "0600"
+            # octal numeric value is supported too
+            # yamllint disable rule:octal-values
+            mode: 0o600
             ca: self-sign
 
     - name: Verify each fs_attrs_mode certificate

--- a/tests/tests_fs_attrs.yml
+++ b/tests/tests_fs_attrs.yml
@@ -11,106 +11,96 @@
         name: somegroup
         gid: 1041
 
-- name: Issue certificate setting user/group
-  hosts: all
-  vars:
-    certificate_requests:
-      - name: mycert_fs_attrs
-        dns: www.example.com
-        owner: ftp
-        group: ftp
-        ca: self-sign
-      - name: certid
-        dns: www.example.com
-        owner: 1040
-        group: 1041
-        ca: self-sign
+    - name: Issue certificate setting user/group
+      include_role:
+        name: linux-system-roles.certificate
+      vars:
+        certificate_requests:
+          - name: mycert_fs_attrs
+            dns: www.example.com
+            owner: ftp
+            group: ftp
+            ca: self-sign
+          - name: certid
+            dns: www.example.com
+            owner: 1040
+            group: 1041
+            ca: self-sign
 
-  roles:
-    - linux-system-roles.certificate
-
-- name: Verify certificate
-  hosts: all
-  vars:
-    certificates:
-      - path: /etc/pki/tls/certs/mycert_fs_attrs.crt
-        key_path: /etc/pki/tls/private/mycert_fs_attrs.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.com
-        subject_alt_name:
-          - name: DNS
-            value: www.example.com
-        owner: ftp
-        group: ftp
-        mode: "0640"
-      - path: /etc/pki/tls/certs/certid.crt
-        key_path: /etc/pki/tls/private/certid.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.com
-        subject_alt_name:
-          - name: DNS
-            value: www.example.com
-        owner: 1040
-        group: 1041
-        mode: "0640"
-  tasks:
-    - name: Verify each certificate
+    - name: Verify each user/group certificate
       include_tasks: tasks/assert_certificate_parameters.yml
       loop: "{{ certificates }}"
       loop_control:
         loop_var: cert
+      vars:
+        certificates:
+          - path: /etc/pki/tls/certs/mycert_fs_attrs.crt
+            key_path: /etc/pki/tls/private/mycert_fs_attrs.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.com
+            subject_alt_name:
+              - name: DNS
+                value: www.example.com
+            owner: ftp
+            group: ftp
+            mode: "0640"
+          - path: /etc/pki/tls/certs/certid.crt
+            key_path: /etc/pki/tls/private/certid.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.com
+            subject_alt_name:
+              - name: DNS
+                value: www.example.com
+            owner: 1040
+            group: 1041
+            mode: "0640"
 
-- name: Issue certificate setting user/group/mode
-  hosts: all
-  vars:
-    certificate_requests:
-      - name: mycert_fs_attrs_mode
-        dns: www.example.com
-        owner: ftp
-        group: ftp
-        mode: "0620"
-        ca: self-sign
-      - name: certid_mode
-        dns: www.example.com
-        mode: "0600"
-        ca: self-sign
+    - name: Issue certificate setting user/group/mode
+      include_role:
+        name: linux-system-roles.certificate
+      vars:
+        certificate_requests:
+          - name: mycert_fs_attrs_mode
+            dns: www.example.com
+            owner: ftp
+            group: ftp
+            mode: "0620"
+            ca: self-sign
+          - name: certid_mode
+            dns: www.example.com
+            mode: "0600"
+            ca: self-sign
 
-  roles:
-    - linux-system-roles.certificate
-
-- name: Verify certificate
-  hosts: all
-  vars:
-    certificates:
-      - path: /etc/pki/tls/certs/mycert_fs_attrs_mode.crt
-        key_path: /etc/pki/tls/private/mycert_fs_attrs_mode.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.com
-        subject_alt_name:
-          - name: DNS
-            value: www.example.com
-        owner: ftp
-        group: ftp
-        mode: "0620"
-      - path: /etc/pki/tls/certs/certid_mode.crt
-        key_path: /etc/pki/tls/private/certid_mode.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.com
-        subject_alt_name:
-          - name: DNS
-            value: www.example.com
-        mode: "0600"
-  tasks:
-    - name: Verify each certificate
+    - name: Verify each fs_attrs_mode certificate
       include_tasks: tasks/assert_certificate_parameters.yml
       loop: "{{ certificates }}"
       loop_control:
         loop_var: cert
+      vars:
+        certificates:
+          - path: /etc/pki/tls/certs/mycert_fs_attrs_mode.crt
+            key_path: /etc/pki/tls/private/mycert_fs_attrs_mode.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.com
+            subject_alt_name:
+              - name: DNS
+                value: www.example.com
+            owner: ftp
+            group: ftp
+            mode: "0620"
+          - path: /etc/pki/tls/certs/certid_mode.crt
+            key_path: /etc/pki/tls/private/certid_mode.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.com
+            subject_alt_name:
+              - name: DNS
+                value: www.example.com
+            mode: "0600"

--- a/tests/tests_many_self_signed.yml
+++ b/tests/tests_many_self_signed.yml
@@ -1,54 +1,54 @@
 ---
 - name: Issue many self-signed certificates
   hosts: all
-  vars:
-    certificate_requests:
-      - name: mycert_many_self_signed
-        dns: www.example.com
-        ca: self-sign
-      - name: other-cert
-        dns: www.example.org
-        ca: self-sign
-      - name: another-cert
-        dns: www.example.net
-        ca: self-sign
-  roles:
-    - linux-system-roles.certificate
 
-- name: Verify certificate
-  hosts: all
-  vars:
-    certificates:
-      - path: /etc/pki/tls/certs/mycert_many_self_signed.crt
-        key_path: /etc/pki/tls/private/mycert_many_self_signed.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.com
-        subject_alt_name:
-          - name: DNS
-            value: www.example.com
-      - path: /etc/pki/tls/certs/other-cert.crt
-        key_path: /etc/pki/tls/private/other-cert.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.org
-        subject_alt_name:
-          - name: DNS
-            value: www.example.org
-      - path: /etc/pki/tls/certs/another-cert.crt
-        key_path: /etc/pki/tls/private/another-cert.key
-        subject:
-          - name: commonName
-            oid: 2.5.4.3
-            value: www.example.net
-        subject_alt_name:
-          - name: DNS
-            value: www.example.net
   tasks:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.certificate
+      vars:
+        certificate_requests:
+          - name: mycert_many_self_signed
+            dns: www.example.com
+            ca: self-sign
+          - name: other-cert
+            dns: www.example.org
+            ca: self-sign
+          - name: another-cert
+            dns: www.example.net
+            ca: self-sign
+
     - name: Verify each certificate
       include_tasks: tasks/assert_certificate_parameters.yml
       loop: "{{ certificates }}"
       loop_control:
         loop_var: cert
+      vars:
+        certificates:
+          - path: /etc/pki/tls/certs/mycert_many_self_signed.crt
+            key_path: /etc/pki/tls/private/mycert_many_self_signed.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.com
+            subject_alt_name:
+              - name: DNS
+                value: www.example.com
+          - path: /etc/pki/tls/certs/other-cert.crt
+            key_path: /etc/pki/tls/private/other-cert.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.org
+            subject_alt_name:
+              - name: DNS
+                value: www.example.org
+          - path: /etc/pki/tls/certs/another-cert.crt
+            key_path: /etc/pki/tls/private/another-cert.key
+            subject:
+              - name: commonName
+                oid: 2.5.4.3
+                value: www.example.net
+            subject_alt_name:
+              - name: DNS
+                value: www.example.net

--- a/tests/tests_many_self_signed.yml
+++ b/tests/tests_many_self_signed.yml
@@ -17,6 +17,14 @@
           - name: another-cert
             dns: www.example.net
             ca: self-sign
+      when: not __bootc_validation | d(false)
+
+    - name: Create QEMU deployment during bootc end-to-end test
+      delegate_to: localhost
+      become: false
+      command: "{{ lsr_scriptdir }}/bootc-buildah-qcow.sh {{ ansible_host }}"
+      changed_when: true
+      when: ansible_connection == "buildah"
 
     - name: Verify each certificate
       include_tasks: tasks/assert_certificate_parameters.yml

--- a/tests/tests_not_wait_for_cert.yml
+++ b/tests/tests_not_wait_for_cert.yml
@@ -30,6 +30,8 @@
         path: "{{ item.path }}"
         timeout: 5
       loop: "{{ certificates }}"
+      # cert isn't actually generated during buildah build
+      when: ansible_connection != "buildah"
 
     - name: Verify each certificate
       include_tasks: tasks/assert_certificate_parameters.yml

--- a/tests/tests_run_hooks.yml
+++ b/tests/tests_run_hooks.yml
@@ -35,6 +35,8 @@
         loop_var: cert
 
     - name: Verify test files timestamp
+      # certmonger does not actually run in buildah
+      when: ansible_connection != "buildah"
       block:
         - name: Get certificate timestamp
           stat:

--- a/tests/tests_test_mode.yml
+++ b/tests/tests_test_mode.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test test mode
   hosts: all
+  tags:
+    # test mode is not supported in container build environments
+    - tests::booted
   vars:
     __test_cert_name1: lsr_cert_test_mode_1
     __test_cert_name2: lsr_cert_test_mode_2


### PR DESCRIPTION
Feature: Support running the certificate role during container builds.

Reason: This is particularly useful for building bootc derivative OSes.

Result: The role is now officially supported for image mode builds.

In non-booted environments, create a systemd unit that runs the `getcert` command(s) on first boot, instead of running it directly. We unfortunately cannot use `ConditionFirstBoot=` for that (https://github.com/systemd/systemd/issues/8268) nor the `ConditionFileNotEmpty=!/etc/machine-id` trick, as certmonger cannot run that early in the boot sequence, and thus even on the first boot /etc/machine-id is created earlier. So instead conditionalize the unit on the commands file and remove that after success.

Adjust assert_certificate_parameters.yml to only check for the generated certificate in non-buildah environments. For buildah, instead check that the first-boot unit was created and enabled.

Make tests_many_self_signed.yml and tests_fs_attrs full bootc end-to-end tests. We don't have to do that for all tests, as the mechanics of the unit generation are fully generic. The most complicated cases are creating more than one certificate and changing the permissions afterwards, which these tests capture.

https://issues.redhat.com/browse/RHEL-93207

## Summary by Sourcery

Enable the certificate role to operate in container (buildah) environments by deferring certificate requests to first-boot systemd units and updating provider logic and tests accordingly.

New Features:
- Introduce a ‘booted’ parameter to toggle immediate vs deferred certificate creation
- Batch certificate commands into a file and create/enable a first-boot systemd unit in non-booted/container builds
- Support container builds by verifying unit creation and enablement instead of direct certificate files

Enhancements:
- Detect systemd runtime availability and set a ‘__certificate_is_booted’ flag
- Conditionally start provider services and adjust task execution based on booted state
- Refactor certmonger provider to accumulate commands and handle permissions in non-booted mode

Tests:
- Split certificate assertions for buildah vs non-buildah, checking systemd unit state in buildah
- Add QEMU bootc end-to-end scenarios in tests_fs_attrs and tests_many_self_signed for container validation
- Tag and skip tests that require a booted environment (e.g., IPA, test mode) in container builds

## Summary by Sourcery

Enable the certificate role to support container/image-mode builds by deferring certificate requests to a first-boot systemd unit when not running on a booted host, with corresponding provider, task, test, and documentation updates.

New Features:
- Introduce a “booted” parameter to toggle immediate versus deferred certificate creation
- Batch certificate commands into a file and create/enable a first-boot systemd unit for non-booted/container builds
- Support container/buildah image-mode builds by deferring certificate operations to first-boot units and verifying their setup instead of direct file checks

Enhancements:
- Detect systemd runtime availability at role startup to set a __certificate_is_booted flag
- Refactor certmonger and base providers to accumulate deferred commands and apply permissions in non-booted mode
- Conditionally start provider services and adjust task execution based on booted state

Documentation:
- Update README to accept octal file modes
- Add “containerbuild” to supported platforms in meta/main.yml

Tests:
- Branch assertion tasks between direct certificate checks and buildah unit validations
- Convert existing fs_attrs and many_self_signed tests into bootc QEMU end-to-end scenarios with buildah validations
- Tag and skip tests that require a booted environment in container builds