### PR TITLE
refactor: fix ansible-lint issue with setup_ipa

### DIFF
--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -89,7 +89,7 @@
     line: "{{ ansible_default_ipv4.address }}  ipaserver.test.local"
     state: present
     insertafter: EOF
-    create: True
+    create: true
     owner: root
     group: root
     mode: "0644"


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Change the 'create' parameter value from True to lowercase true in the setup_ipa task.