### PR TITLE
test: reset hostname after ipa test

### DIFF
--- a/tests/tasks/setup_ipa.yml
+++ b/tests/tasks/setup_ipa.yml
@@ -58,6 +58,11 @@
     use: "{{ (__certificate_is_ostree | d(false)) |
       ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
+- name: Get hostname
+  command: hostname
+  changed_when: false
+  register: __saved_hostname
+
 - name: Set hostname
   hostname:
     name: ipaserver.test.local

--- a/tests/tests_basic_ipa.yml
+++ b/tests/tests_basic_ipa.yml
@@ -99,3 +99,9 @@
               - content_commitment
               - key_encipherment
               - data_encipherment
+
+    - name: Reset hostname
+      hostname:
+        name: "{{ __saved_hostname.stdout }}"
+        use: systemd
+      when: ansible_facts.os_family == "RedHat"


### PR DESCRIPTION
The tests_basic_ipa.yml test has to set a hostname for IPA
to work.  We need to reset the hostname after the test.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Save the original hostname before setting the IPA test hostname and restore it after the tests on RedHat systems

Enhancements:
- Record the current hostname before changing it for the IPA test
- Add a teardown task to reset the hostname to its original value after the test