### PR TITLE
feat: Implement support for passing an issuer argument to the provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Alternative Names (SAN).
 |----------------------|---------------------------------------------------------------------------------------------------|:-----------:|:--------:|-------------------------|
 | name                 | Name of the certificate. A full path can be used to choose the directory where files will be stored.| str       | yes      | -                       |
 | ca                   | CA that will issue the certificate. See [CAs and Providers](#cas-and-providers).                  | str         | yes      | -                       |
+| issuer               | The name of the issuer at the CA that will issue the certificate. The interpretation of the issuer may vary depending on each provider, and may be ignored if the CA only has one or a default issuer. | str | no | - |
 | dns                  | Domain (or list of domains) to be included in the certificate. Also can provide the default value for [common\_name](#common_name). | str or list | no | - |
 | email                | Email (or list of emails) to be included in the certificate.                                      | str or list | no       | -                       |
 | ip                   | IP, or list of IPs, to be included in the certificate. IPs can be IPv4, IPv6 or both. Also can provide the default value for [common\_name](#common_name). | str or list | no | - |

--- a/library/certificate_request.py
+++ b/library/certificate_request.py
@@ -78,6 +78,12 @@ options:
         will vary depending on each provider.
     type: str
     required: true
+  issuer:
+    description:
+      - The name of the issuer at the CA that will issue the certificate.
+        The interpretation of the issuer may vary depending on each provider,
+        and may be ignored if the CA only has one or a default issuer.
+    type: str
   provider:
     description:
       - The underlying method used to request and manage the
@@ -368,6 +374,7 @@ class CertificateRequestModule(AnsibleModule):
             organizational_unit=dict(type="str"),
             contact_email=dict(type="str"),
             ca=dict(type="str", required=True),
+            issuer=dict(type="str"),
             directory=dict(type="str", default="/etc/pki/tls"),
             provider_config_directory=dict(type="str", default="/etc/certmonger"),
             provider=dict(type="str", default="certmonger"),

--- a/module_utils/certificate_lsr/providers/certmonger.py
+++ b/module_utils/certificate_lsr/providers/certmonger.py
@@ -183,6 +183,12 @@ class CertificateRequestCertmongerProvider(base.CertificateRequestBaseProvider):
     def _get_certmonger_ca_for_existing_cert(self):
         return self._certmonger_metadata.get("ca")
 
+    def _get_certmonger_issuer_from_params(self):
+        return self.module.params.get("issuer")
+
+    def _get_certmonger_issuer_for_existing_cert(self):
+        return self._certmonger_metadata.get("template-issuer")
+
     @property
     def cert_needs_update(self):
         """Check if the existing_certificate needs update.
@@ -200,7 +206,24 @@ class CertificateRequestCertmongerProvider(base.CertificateRequestBaseProvider):
                 ca_from_params == ca_from_existing_cert
             )
         )
-        if needs_update or ca_from_params != ca_from_existing_cert:
+
+        issuer_from_params = self._get_certmonger_issuer_from_params()
+        issuer_from_existing_cert = self._get_certmonger_issuer_for_existing_cert()
+        issuer_needs_update = (
+            issuer_from_params is not None
+            and issuer_from_params != issuer_from_existing_cert
+        )
+        self.module.debug(
+            "issuer_from_params == issuer_from_existing_cert: {0}".format(
+                issuer_from_params == issuer_from_existing_cert
+            )
+        )
+
+        if (
+            needs_update
+            or ca_from_params != ca_from_existing_cert
+            or issuer_needs_update
+        ):
             return True
 
         return False
@@ -327,6 +350,10 @@ class CertificateRequestCertmongerProvider(base.CertificateRequestBaseProvider):
 
         # Set CA
         command += ["-c", self._get_certmonger_ca_from_params()]
+
+        # Set issuer
+        if self.module.params.get("issuer"):
+            command += ["-X", self.module.params.get("issuer")]
 
         # Wait for cert if required
         if self.module.params["wait"]:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -157,6 +157,7 @@
     run_before: "{{ item.run_before | default(omit) }}"
     run_after: "{{ item.run_after | default(omit) }}"
     ca: "{{ item.ca | default(omit) }}"
+    issuer: "{{ item.issuer | default(omit) }}"
     __header: "{{ __lsr_ansible_managed }}"
     booted: "{{ __certificate_is_booted }}"
   loop: "{{ certificate_requests }}"

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -193,6 +193,25 @@
           {{ cert['auto_renew'] | default('yes') | bool }} !=
           {{ result.stdout | bool }}
 
+    - name: Retrieve issuer template
+      shell: >-
+        set -euo pipefail;
+        getcert list -f {{ cert['path'] }} |
+        grep 'issuer template' |
+        sed 's/^\s\+issuer template: //g'
+      register: result
+      changed_when: false
+      when: cert.issuer_template is defined
+
+    - name: Verify certificate issuer template
+      assert:
+        that:
+          - cert['issuer_template'] | trim == result.stdout | trim
+        fail_msg: >-
+          {{ cert['issuer_template'] | trim }} !=
+          {{ result.stdout | trim }}
+      when: cert.issuer_template is defined
+
     - name: Stat commands file
       stat:
         path: /var/lib/certmonger/system-roles-create.commands

--- a/tests/tests_issuer.yml
+++ b/tests/tests_issuer.yml
@@ -1,0 +1,52 @@
+---
+- name: Issue self-signed certificate
+  hosts: all
+  vars:
+    certificate_requests:
+      - name: mycert_subject
+        dns: www.example.com
+        ca: self-sign
+        issuer: mycert_issuer
+  tasks:
+    - name: Run the role
+      include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
+
+- name: Verify certificate
+  hosts: all
+  pre_tasks:
+    - name: Load certificate role platform variables
+      include_role:
+        name: linux-system-roles.certificate
+        tasks_from: set_vars.yml
+        public: true
+  vars:
+    certificates:
+      - path: "{{ __certificate_default_directory }}/certs/mycert_subject.crt"
+        key_path: "{{ __certificate_default_directory }}/private/mycert_subject.key"
+        subject:
+          - name: commonName
+            oid: 2.5.4.3
+            value: www.example.com
+        subject_alt_name:
+          - name: DNS
+            value: www.example.com
+        issuer_template: mycert_issuer
+  tasks:
+    - name: Verify each certificate
+      include_tasks: tasks/assert_certificate_parameters.yml
+      loop: "{{ certificates }}"
+      loop_control:
+        loop_var: cert


### PR DESCRIPTION
Enhancement:
Implement support for passing an issuer argument to the provider.

Reason:
This enables the usage of FreeIPA sub-CAs, which use the "IPA" CA in certmonger but have a separate issuer.

Result:
Users can issue certificates signed by IPAs sub-CAs.

Issue Tracker Tickets (Jira or BZ if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `issuer` support for certificate requests, including per-certificate configuration.
  * Certificate issuance now respects the requested issuer when supported.

* **Bug Fixes**
  * Certificate refresh logic detects issuer mismatches and updates certificates when necessary.

* **Documentation & Tests**
  * Documented the new `issuer` parameter.
  * Added end-to-end validation for issuer handling and idempotent certificate requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->