### PR TITLE
test: ignore Fedora and EL10 cert parsing error due to certmonger 309

### DIFF
--- a/tests/library/certtojson.py
+++ b/tests/library/certtojson.py
@@ -249,10 +249,14 @@ def main():
         argument_spec={"filename": {"type": "str", "required": True}},
         supports_check_mode=False,
     )
-    module.exit_json(
-        changed=False,
-        certificate=decode_certificate(module.params.get("filename")),
-    )
+    result = {"changed": False, "certificate": None}
+    try:
+        certificate = decode_certificate(module.params.get("filename"))
+        result["certificate"] = certificate
+    except Exception as exc:
+        result["msg"] = str(exc)
+        module.fail_json(**result)
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -92,64 +92,89 @@
           {{ cert['owner'] | default('root') }}:
           {{ cert['group'] | default('root') }}
 
+    # NOTE: Due a bug in certmonger which is fixed by
+    # https://codeberg.org/freeipa/certmonger/pulls/309
+    # certmonger does not use the proper encoding for subject/common name
+    # values which contain non-printable characters, such as used in
+    # tests_subject_complex.yml. And the pyca parser used by certtojson
+    # in EL10 and Fedora is much stricter and does not like the encoding.
+    # So ignore for now.
     - name: Parse certificate
       certtojson:
         filename: "{{ cert['path'] }}"
       register: certificate_data
       changed_when: false
+      failed_when:
+        - certificate_data is failed
+        - not _is_affected or certificate_data.msg is not search(_msg)
+      vars:
+        _msg: >-
+          ParseError { kind: UnexpectedTag { actual: Tag { value: 13, constructed: true, class: Universal } } }
+        _is_affected: "{{ ((ansible_facts['distribution_major_version'] == '10' and
+          ansible_facts['os_family'] == 'RedHat'))
+          or ansible_facts['distribution'] == 'Fedora' }}"
 
-    - name: Load certificate YAML to cert_issued variable
-      set_fact:
+    - name: Report error when certificate parsing failed
+      debug:
+        msg: >-
+          Certificate parsing failed - this is likely due to a bug in certmonger which
+          is fixed by https://codeberg.org/freeipa/certmonger/pulls/309 -
+          message: {{ certificate_data.msg }}
+      when: certificate_data.certificate is none
+
+    - name: Ignore other checks if certificate parsing failed
+      when: certificate_data.certificate is not none
+      vars:
         cert_issued: "{{ certificate_data.certificate }}"
+      block:
+        - name: Verify certificate subject
+          assert:
+            that:
+              - cert.subject | sort(attribute="name") ==
+                cert_issued.subject | sort(attribute="name")
+            fail_msg: >-
+              {{ cert.subject | sort(attribute="name") }} !=
+              {{ cert_issued.subject | sort(attribute="name") }}
 
-    - name: Verify certificate subject
-      assert:
-        that:
-          - cert.subject | sort(attribute="name") ==
-            cert_issued.subject | sort(attribute="name")
-        fail_msg: >-
-          {{ cert.subject | sort(attribute="name") }} !=
-          {{ cert_issued.subject | sort(attribute="name") }}
+        - name: Verify certificate SAN
+          assert:
+            that:
+              - cert.subject_alt_name ==
+                cert_issued.extensions.subjectAltName.value
+            fail_msg: >-
+              {{ cert.subject_alt_name }} !=
+              {{ cert_issued.extensions.subjectAltName.value }}
 
-    - name: Verify certificate SAN
-      assert:
-        that:
-          - cert.subject_alt_name ==
-            cert_issued.extensions.subjectAltName.value
-        fail_msg: >-
-          {{ cert.subject_alt_name }} !=
-          {{ cert_issued.extensions.subjectAltName.value }}
+        - name: Verify key size
+          assert:
+            that:
+              - cert.key_size | default(2048) == cert_issued.key_size
+            fail_msg: >-
+              {{ cert.key_size | default(2048) }} != {{ cert_issued.key_size }}
 
-    - name: Verify key size
-      assert:
-        that:
-          - cert.key_size | default(2048) == cert_issued.key_size
-        fail_msg: >-
-          {{ cert.key_size | default(2048) }} != {{ cert_issued.key_size }}
+        - name: Verify certificate Key Usage
+          vars:
+            default_ku:
+              - digital_signature
+              - key_encipherment
+            expected: "{{ cert.key_usage | d(default_ku) | sort }}"
+            actual: "{{ cert_issued.extensions.keyUsage.value | sort }}"
+          assert:
+            that: expected == actual
+            fail_msg: expected value {{ expected }} != {{ actual }}
 
-    - name: Verify certificate Key Usage
-      vars:
-        default_ku:
-          - digital_signature
-          - key_encipherment
-        expected: "{{ cert.key_usage | d(default_ku) | sort }}"
-        actual: "{{ cert_issued.extensions.keyUsage.value | sort }}"
-      assert:
-        that: expected == actual
-        fail_msg: expected value {{ expected }} != {{ actual }}
-
-    - name: Verify certificate Extended Key Usage
-      vars:
-        default_eku:
-          - name: id-kp-serverAuth
-            oid: 1.3.6.1.5.5.7.3.1
-          - name: id-kp-clientAuth
-            oid: 1.3.6.1.5.5.7.3.2
-        expected: "{{ cert.extended_key_usage | d(default_eku) }}"
-        actual: "{{ cert_issued.extensions.extendedKeyUsage.value }}"
-      assert:
-        that: expected == actual
-        fail_msg: expected value {{ expected }} != {{ actual }}
+        - name: Verify certificate Extended Key Usage
+          vars:
+            default_eku:
+              - name: id-kp-serverAuth
+                oid: 1.3.6.1.5.5.7.3.1
+              - name: id-kp-clientAuth
+                oid: 1.3.6.1.5.5.7.3.2
+            expected: "{{ cert.extended_key_usage | d(default_eku) }}"
+            actual: "{{ cert_issued.extensions.extendedKeyUsage.value }}"
+          assert:
+            that: expected == actual
+            fail_msg: expected value {{ expected }} != {{ actual }}
 
     - name: Retrieve auto-renew flag
       shell: >-


### PR DESCRIPTION
Due to a bug fixed in https://codeberg.org/freeipa/certmonger/pulls/309
certmonger does not use the proper encoding for subject/common name
values which contain non-printable characters, such as used in
tests_subject_complex.yml. And the Fedora and EL10 pyca parser used by certtojson
is much stricter and does not like the encoding.  So ignore for now.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved certificate validation reliability for known encoding issues on Red Hat 10 and Fedora.
* Certificate parsing failures are now reported clearly with relevant error details.
* Certificate content checks are skipped when parsing is unavailable, preventing misleading validation results.
* Subject, SAN, key size, Key Usage, and Extended Key Usage checks now use successfully parsed certificate data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->