### PR TITLE
fix: ensure role is idempotent

### DIFF
--- a/module_utils/certificate_lsr/providers/base.py
+++ b/module_utils/certificate_lsr/providers/base.py
@@ -480,15 +480,18 @@ class CertificateProxy:
             return []
         return ext
 
-    def __eq__(self, other):
+    def __eq__(self, cert_request):
         """Compare two instances of CertificateProxy for idempotency purposes."""
+        # NOTE: This only works if the cert_request is the cert requested by the user.
+        # that is - cert_from_pem != cert_from_module_params
+        # it will not work if the cert_request is a certificate from the pem file
         # TODO: compare CA here
         #   Currently each provider is responsible for implementing the CA
         #   comparison.
-        if not isinstance(other, CertificateProxy):
+        if not isinstance(cert_request, CertificateProxy):
             raise TypeError(
                 "Cannot compare 'CertificateProxy' with '{0}'".format(
-                    type(other),
+                    type(cert_request),
                 )
             )
 
@@ -496,20 +499,36 @@ class CertificateProxy:
             "Preparing CertificateProxy objects for comparison: "
             "some keys might be added and/or removed."
         )
-        self._module.debug("Original A: {0}".format(pformat(self.cert_data)))
-        self._module.debug("Original B: {0}".format(pformat(other.cert_data)))
+        self._module.debug(
+            "Original cert_from_pem: {0}".format(pformat(self.cert_data))
+        )
+        self._module.debug(
+            "Original cert_from_module_params: {0}".format(
+                pformat(cert_request.cert_data)
+            )
+        )
 
         # Remove empty sequences and strings, false and None values
         #   before comparison happens
-        self_info = {k: v for k, v in self.cert_data.items() if v}
-        other_info = {k: v for k, v in other.cert_data.items() if v}
+        cert_request_info = {k: v for k, v in cert_request.cert_data.items() if v}
+        cert_from_pem_info = {k: v for k, v in self.cert_data.items() if v}
+        # remove key_size if it is empty in the cert_request - if key_size is in the request
+        # it will have a real non-null and non-zero value e.g. 4096
+        if not cert_request.cert_data.get("key_size") and cert_from_pem_info.get(
+            "key_size"
+        ):
+            del cert_from_pem_info["key_size"]
 
         self._module.debug("Comparing CertificateProxy objects:")
-        self._module.debug("A: {0}".format(pformat(self_info)))
-        self._module.debug("B: {0}".format(pformat(other_info)))
+        self._module.debug("cert_from_pem: {0}".format(pformat(cert_from_pem_info)))
+        self._module.debug(
+            "cert_from_module_params: {0}".format(pformat(cert_request_info))
+        )
 
-        equals = self_info == other_info
-        self._module.debug("A == B: {0}".format(equals))
+        equals = cert_from_pem_info == cert_request_info
+        self._module.debug(
+            "cert_from_pem == cert_from_module_params: {0}".format(equals)
+        )
         return equals
 
     def __ne__(self, other):

--- a/module_utils/certificate_lsr/providers/certmonger.py
+++ b/module_utils/certificate_lsr/providers/certmonger.py
@@ -420,6 +420,7 @@ class CertificateRequestCertmongerProvider(base.CertificateRequestBaseProvider):
             return
 
         with open(unit_path, "w") as f:
+            # fmt: off
             f.write("""[Unit]
 Description=Request certificates via certmonger from System Role
 Documentation=https://github.com/linux-system-roles/certificate/

--- a/tasks/certificate_trust.yml
+++ b/tasks/certificate_trust.yml
@@ -16,6 +16,12 @@
   loop: "{{ certificate_trust }}"
   loop_control:
     label: "{{ item.name | d('unnamed') }}"
+  register: __certificate_trust_validated
+
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_trust_validated is changed  # noqa no-handler
 
 - name: Ensure trust store packages are installed
   package:
@@ -23,6 +29,12 @@
     state: present
     use: "{{ (__certificate_is_ostree | d(false)) |
       ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: __certificate_trust_packages_installed
+
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_trust_packages_installed is changed  # noqa no-handler
 
 - name: Install trust certificates
   copy:
@@ -41,6 +53,11 @@
     - item.content is defined or item.src is defined
   register: __certificate_trust_copied
 
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_trust_copied is changed  # noqa no-handler
+
 - name: Install trust certificates from URL
   get_url:
     url: "{{ item.url }}"
@@ -56,6 +73,11 @@
     - item.url is defined
   register: __certificate_trust_downloaded
 
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_trust_downloaded is changed  # noqa no-handler
+
 - name: Remove trust certificates
   file:
     path: "{{ __certificate_trust_dir }}/{{ item.name }}.crt"
@@ -66,9 +88,20 @@
   when: item.state | d('present') == 'absent'
   register: __certificate_trust_removed
 
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_trust_removed is changed  # noqa no-handler
+
 - name: Update system trust store
   command: "{{ __certificate_update_trust_cli }}"
   changed_when: true
   when: __certificate_trust_copied is changed
     or __certificate_trust_downloaded is changed
-    or __certificate_trust_removed is changed
+    or __certificate_trust_removed is changed  # noqa no-handler
+  register: __certificate_trust_updated
+
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_trust_updated is changed  # noqa no-handler

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: Set version specific variables
   include_tasks: tasks/set_vars.yml
 
+- name: Set/reset certificate_is_changed
+  set_fact:
+    certificate_is_changed: false
+
 - name: Install and configure requirements and providers
   when: certificate_requests | length > 0
   vars:
@@ -14,6 +18,12 @@
         state: present
         use: "{{ (__certificate_is_ostree | d(false)) |
           ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      register: __certificate_packages_result
+
+    - name: Set certificate_is_changed
+      set_fact:
+        certificate_is_changed: true
+      when: __certificate_packages_result is changed  # noqa no-handler
 
     - name: Ensure provider packages are installed
       package:
@@ -25,6 +35,12 @@
       loop_control:
         loop_var: __certificate_provider
       when: __certificate_provider_vars[__certificate_provider].packages is defined
+      register: __certificate_provider_packages
+
+    - name: Set certificate_is_changed
+      set_fact:
+        certificate_is_changed: true
+      when: __certificate_provider_packages is changed  # noqa no-handler
 
     - name: Ensure pre-scripts hooks directory exists
       file:
@@ -49,6 +65,12 @@
       loop_control:
         loop_var: __certificate_provider
       when: __certificate_provider_vars[__certificate_provider].config_dir is defined
+      register: __certificate_pre_scripts_dirs
+
+    - name: Set certificate_is_changed
+      set_fact:
+        certificate_is_changed: true
+      when: __certificate_pre_scripts_dirs is changed  # noqa no-handler
 
     - name: Ensure post-scripts hooks directory exists
       file:
@@ -73,6 +95,12 @@
       loop_control:
         loop_var: __certificate_provider
       when: __certificate_provider_vars[__certificate_provider].config_dir is defined
+      register: __certificate_post_scripts_dirs
+
+    - name: Set certificate_is_changed
+      set_fact:
+        certificate_is_changed: true
+      when: __certificate_post_scripts_dirs is changed  # noqa no-handler
 
     # While most Linux system roles have a list of services
     #   this role doesn't need it. In fact some providers
@@ -86,6 +114,12 @@
       loop_control:
         loop_var: __certificate_provider
       when: __certificate_provider_vars[__certificate_provider].service is defined
+      register: __certificate_provider_service
+
+    - name: Set certificate_is_changed
+      set_fact:
+        certificate_is_changed: true
+      when: __certificate_provider_service is changed  # noqa no-handler
 
 - name: Ensure certificates in the system trust store
   include_tasks: tasks/certificate_trust.yml
@@ -129,6 +163,12 @@
   vars:
     __lsr_ansible_managed: "{{
       lookup('template', 'get_ansible_managed.j2') }}"
+  register: __certificate_requests
+
+- name: Set certificate_is_changed
+  set_fact:
+    certificate_is_changed: true
+  when: __certificate_requests is changed  # noqa no-handler
 
 # For using this role to issue certs for tests for other
 # system roles.  Assumes that the calling role wants

--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -106,7 +106,7 @@
       changed_when: false
       failed_when:
         - certificate_data is failed
-        - not _is_affected or certificate_data.msg is not search(_msg)
+        - not _is_affected or certificate_data.msg is not search(_msg | regex_escape)
       vars:
         _msg: >-
           ParseError { kind: UnexpectedTag { actual: Tag { value: 13, constructed: true, class: Universal } } }

--- a/tests/tests_basic_ipa.yml
+++ b/tests/tests_basic_ipa.yml
@@ -7,6 +7,18 @@
     # can't run IPA in a buildah system
     # this is a test restriction, not a role restriction
     - tests::booted
+  vars:
+    certificate_requests:
+      - name: mycert_basic_ipa
+        dns: ipaserver.test.local
+        principal: HTTP/ipaserver.test.local@TEST.LOCAL
+        ca: ipa
+
+      - name: groupcert
+        dns: ipaserver.test.local
+        principal: HTTP/ipaserver.test.local@TEST.LOCAL
+        ca: ipa
+        group: ftp
   tasks:
     - name: Check if test is supported
       vars:
@@ -28,17 +40,18 @@
     - name: Issue IPA signed certificates
       include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
-        certificate_requests:
-          - name: mycert_basic_ipa
-            dns: ipaserver.test.local
-            principal: HTTP/ipaserver.test.local@TEST.LOCAL
-            ca: ipa
+        __sr_public: true
 
-          - name: groupcert
-            dns: ipaserver.test.local
-            principal: HTTP/ipaserver.test.local@TEST.LOCAL
-            ca: ipa
-            group: ftp
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
     - name: Load certificate role platform variables
       include_role:

--- a/tests/tests_basic_self_signed.yml
+++ b/tests/tests_basic_self_signed.yml
@@ -9,6 +9,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -16,7 +16,19 @@
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
+        __sr_public: true
         __certificate_write_log_file: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
     # look for the exact module invocation, not some other message that might contain the string
     - name: Get fingerprint entries from journal

--- a/tests/tests_dns_ip_email.yml
+++ b/tests/tests_dns_ip_email.yml
@@ -21,6 +21,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_fs_attrs.yml
+++ b/tests/tests_fs_attrs.yml
@@ -1,6 +1,31 @@
 ---
 - name: Ensure UID and GID exists
   hosts: all
+  vars:
+    __certificate_requests_fs_attrs:
+      - name: mycert_fs_attrs
+        dns: www.example.com
+        owner: ftp
+        group: ftp
+        ca: self-sign
+      - name: certid
+        dns: www.example.com
+        owner: 1040
+        group: 1041
+        ca: self-sign
+    __certificate_requests_fs_attrs_mode:
+      - name: mycert_fs_attrs_mode
+        dns: www.example.com
+        owner: ftp
+        group: ftp
+        mode: "0620"
+        ca: self-sign
+      - name: certid_mode
+        dns: www.example.com
+        # octal numeric value is supported too
+        # yamllint disable rule:octal-values
+        mode: 0o600
+        ca: self-sign
   tasks:
     - name: Ensure ftp group exists
       group:
@@ -32,20 +57,25 @@
       when: not __bootc_validation | d(false)
 
     - name: Issue certificate setting user/group
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        certificate_requests:
-          - name: mycert_fs_attrs
-            dns: www.example.com
-            owner: ftp
-            group: ftp
-            ca: self-sign
-          - name: certid
-            dns: www.example.com
-            owner: 1040
-            group: 1041
-            ca: self-sign
       when: not __bootc_validation | d(false)
+      vars:
+        certificate_requests: "{{ __certificate_requests_fs_attrs }}"
+      block:
+        - name: Issue certificate setting user/group
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+
+        - name: Check idempotency if system is booted
+          when: __certificate_is_booted
+          block:
+            - name: Run the role again to test idempotency
+              include_tasks: tasks/run_role_with_clear_facts.yml
+
+            - name: Assert no changes were made
+              assert:
+                that: not certificate_is_changed
+                fail_msg: "Certificate was changed when it should not have been"
 
     - name: Load certificate role platform variables
       include_role:
@@ -86,22 +116,25 @@
             mode: "0640"
 
     - name: Issue certificate setting user/group/mode
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        certificate_requests:
-          - name: mycert_fs_attrs_mode
-            dns: www.example.com
-            owner: ftp
-            group: ftp
-            mode: "0620"
-            ca: self-sign
-          - name: certid_mode
-            dns: www.example.com
-            # octal numeric value is supported too
-            # yamllint disable rule:octal-values
-            mode: 0o600
-            ca: self-sign
       when: not __bootc_validation | d(false)
+      vars:
+        certificate_requests: "{{ __certificate_requests_fs_attrs_mode }}"
+      block:
+        - name: Issue certificate setting user/group/mode
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+
+        - name: Check idempotency if system is booted
+          when: __certificate_is_booted
+          block:
+            - name: Run the role again to test idempotency
+              include_tasks: tasks/run_role_with_clear_facts.yml
+
+            - name: Assert no changes were made
+              assert:
+                that: not certificate_is_changed
+                fail_msg: "Certificate was changed when it should not have been"
 
     - name: Create QEMU deployment during bootc end-to-end test
       delegate_to: localhost

--- a/tests/tests_key_size.yml
+++ b/tests/tests_key_size.yml
@@ -1,6 +1,12 @@
 ---
 - name: Test certificate generation with key_size
   hosts: all
+  vars:
+    certificate_requests:
+      - name: mycert_key_size
+        dns: www.example.com
+        ca: self-sign
+        key_size: 1024
 
   tasks:
     - name: Include role, ignore fail if certmonger version is not supported
@@ -8,11 +14,18 @@
         - name: Request certificate with key size
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
-            certificate_requests:
-              - name: mycert_key_size
-                dns: www.example.com
-                ca: self-sign
-                key_size: 1024
+            __sr_public: true
+
+        - name: Check idempotency if system is booted
+          when: __certificate_is_booted
+          block:
+            - name: Run the role again to test idempotency
+              include_tasks: tasks/run_role_with_clear_facts.yml
+
+            - name: Assert no changes were made
+              assert:
+                that: not certificate_is_changed
+                fail_msg: "Certificate was changed when it should not have been"
 
         - name: Load certificate role platform variables
           include_role:

--- a/tests/tests_key_size_reissue.yml
+++ b/tests/tests_key_size_reissue.yml
@@ -2,17 +2,37 @@
 - name: Test re-issue certificate if key size changes
   hosts: all
   become: false
+  vars:
+    __certificate_requests_4096:
+      - name: mycert_key_size
+        dns: www.example.com
+        ca: self-sign
+        key_size: 4096
+    __certificate_requests_3072:
+      - name: mycert_key_size
+        dns: www.example.com
+        ca: self-sign
+        key_size: 3072
   tasks:
     - name: Include role, ignore fail if certmonger version is not supported
+      vars:
+        certificate_requests: "{{ __certificate_requests_4096 }}"
       block:
         - name: Request certificate with key size
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
-            certificate_requests:
-              - name: mycert_key_size
-                dns: www.example.com
-                ca: self-sign
-                key_size: 4096
+            __sr_public: true
+
+        - name: Check idempotency if system is booted
+          when: __certificate_is_booted
+          block:
+            - name: Run the role again to test idempotency
+              include_tasks: tasks/run_role_with_clear_facts.yml
+
+            - name: Assert no changes were made
+              assert:
+                that: not certificate_is_changed
+                fail_msg: "Certificate was changed when it should not have been"
 
         - name: Load certificate role platform variables
           include_role:
@@ -52,13 +72,24 @@
               meta: end_play
 
     - name: Request certificate with key size 3072
-      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
-        certificate_requests:
-          - name: mycert_key_size
-            dns: www.example.com
-            ca: self-sign
-            key_size: 3072
+        certificate_requests: "{{ __certificate_requests_3072 }}"
+      block:
+        - name: Request certificate with key size 3072
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+
+        - name: Check idempotency if system is booted
+          when: __certificate_is_booted
+          block:
+            - name: Run the role again to test idempotency
+              include_tasks: tasks/run_role_with_clear_facts.yml
+
+            - name: Assert no changes were made
+              assert:
+                that: not certificate_is_changed
+                fail_msg: "Certificate was changed when it should not have been"
 
     - name: Fail if certificate was not updated.
       fail:

--- a/tests/tests_key_usage_and_extended_key_usage.yml
+++ b/tests/tests_key_usage_and_extended_key_usage.yml
@@ -18,6 +18,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_many_self_signed.yml
+++ b/tests/tests_many_self_signed.yml
@@ -1,22 +1,35 @@
 ---
 - name: Issue many self-signed certificates
   hosts: all
+  vars:
+    certificate_requests:
+      - name: mycert_many_self_signed
+        dns: www.example.com
+        ca: self-sign
+      - name: other-cert
+        dns: www.example.org
+        ca: self-sign
+      - name: another-cert
+        dns: www.example.net
+        ca: self-sign
 
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        certificate_requests:
-          - name: mycert_many_self_signed
-            dns: www.example.com
-            ca: self-sign
-          - name: other-cert
-            dns: www.example.org
-            ca: self-sign
-          - name: another-cert
-            dns: www.example.net
-            ca: self-sign
       when: not __bootc_validation | d(false)
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __bootc_validation | default(false) or __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
     - name: Create QEMU deployment during bootc end-to-end test
       delegate_to: localhost

--- a/tests/tests_no_auto_renew.yml
+++ b/tests/tests_no_auto_renew.yml
@@ -13,6 +13,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   pre_tasks:

--- a/tests/tests_not_wait_for_cert.yml
+++ b/tests/tests_not_wait_for_cert.yml
@@ -10,6 +10,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_principal.yml
+++ b/tests/tests_principal.yml
@@ -10,6 +10,20 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that:
+              - not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_provider.yml
+++ b/tests/tests_provider.yml
@@ -10,6 +10,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_run_hooks.yml
+++ b/tests/tests_run_hooks.yml
@@ -13,6 +13,20 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that:
+              - not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_subject.yml
+++ b/tests/tests_subject.yml
@@ -15,6 +15,19 @@
   tasks:
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
+
+    - name: Check idempotency if system is booted
+      when: __certificate_is_booted
+      block:
+        - name: Run the role again to test idempotency
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Assert no changes were made
+          assert:
+            that: not certificate_is_changed
+            fail_msg: "Certificate was changed when it should not have been"
 
 - name: Verify certificate
   hosts: all

--- a/tests/tests_subject_complex.yml
+++ b/tests/tests_subject_complex.yml
@@ -9,13 +9,63 @@
         common_name: '# \\Every"thing+that,ne;eds<escap>ing\0 '
         contact_email: admin@example.com
         ca: self-sign
+  vars_files:
+    - vars/rh_distros_vars.yml
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
+    - name: Run the role and handle errors
+      block:
+        - name: Run the role
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+
+        - name: Set fact __is_el7
+          set_fact:
+            __is_el7: __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '7'
+
+        # The el7 issue is different but related to the el10 certmonger encoding - the comma
+        # causes certmonger to encode the subject as two different values.
+        - name: Check idempotency if system is booted
+          when:
+            - __certificate_is_booted
+            - not __is_el7
+          block:
+            - name: Run the role again to test idempotency
+              include_tasks: tasks/run_role_with_clear_facts.yml
+
+            - name: Assert no changes were made
+              assert:
+                that: not certificate_is_changed
+                fail_msg: "Certificate was changed when it should not have been"
+      rescue:
+        - name: Check for expected error and fail otherwise
+          fail:
+            msg: >-
+              Certificate parsing failed - this is likely due to a bug in certmonger which
+              is fixed by https://codeberg.org/freeipa/certmonger/pulls/309 -
+              message: {{ ansible_failed_result.msg }}
+          when: not _is_affected or ansible_failed_result.results |
+            selectattr('msg', 'search', _msg | regex_escape) | list | length == 0
+          vars:
+            _msg: >-
+              ParseError { kind: InvalidValue, location: [1, 0, "AttributeTypeValue::value", "AttributeValue::PrintableString"] }
+            _is_affected: "{{ ((ansible_facts['distribution_major_version'] == '10' and
+              ansible_facts['os_family'] == 'RedHat'))
+              or ansible_facts['distribution'] == 'Fedora' }}"
+
+        - name: Tell remaining tasks to skip
+          set_fact:
+            skip_remaining_tasks: true
 
 - name: Verify certificate
   hosts: all
+  vars_files:
+    - vars/rh_distros_vars.yml
   pre_tasks:
+    - name: Skip tasks if expected error occurred
+      when: skip_remaining_tasks | default(false)
+      meta: end_play
+
     - name: Load certificate role platform variables
       include_role:
         name: linux-system-roles.certificate
@@ -38,11 +88,7 @@
             value: www.example.com
   tasks:
     - name: Verify certs if not CentOS/RedHat 7
-      when: |
-        not (
-            ansible_facts["distribution"] in ['CentOS', 'RedHat'] and
-            ansible_facts["distribution_major_version"] == "7"
-        )
+      when: not (__certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '7')
       block:
         - name: Verify each certificate
           include_tasks: tasks/assert_certificate_parameters.yml

--- a/tests/tests_trust.yml
+++ b/tests/tests_trust.yml
@@ -3,8 +3,21 @@
 - name: Test adding certificates to the system trust store
   hosts: all
   vars:
+    __sr_public: true
     __trust_test_ca_cert: "{{ __trust_test_ca_tempdir.path }}/ca.crt"
     __trust_test_ca_key: "{{ __trust_test_ca_tempdir.path }}/ca.key"
+    __certificate_trust_src:
+      - name: lsr-trust-test-src
+        src: "{{ __trust_test_ca_cert }}"
+        remote_src: true
+    __certificate_trust_content:
+      - name: lsr-trust-test-content
+        content: "{{ __trust_test_ca_slurp.content | b64decode }}"
+    __certificate_trust_absent:
+      - name: lsr-trust-test-src
+        state: absent
+      - name: lsr-trust-test-content
+        state: absent
   tasks:
     - name: Run certificate_trust tests
       block:
@@ -45,14 +58,25 @@
           assert:
             that: "__trust_verify_before.stdout is not search(': OK')"
 
-        - name: Run the role to trust a certificate file on the managed host
-          include_tasks: tasks/run_role_with_clear_facts.yml
+        - name: Trust a certificate file on the managed host
           vars:
-            __sr_public: true
-            certificate_trust:
-              - name: lsr-trust-test-src
-                src: "{{ __trust_test_ca_cert }}"
-                remote_src: true
+            certificate_trust: "{{ __certificate_trust_src }}"
+          block:
+            - name: Run the role to trust a certificate file on the managed host
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                __sr_public: true
+
+            - name: Check idempotency if system is booted
+              when: __certificate_is_booted
+              block:
+                - name: Run the role again to test idempotency
+                  include_tasks: tasks/run_role_with_clear_facts.yml
+
+                - name: Assert no changes were made
+                  assert:
+                    that: not certificate_is_changed
+                    fail_msg: "Certificate was changed when it should not have been"
 
         - name: Get the trust anchor file attributes
           stat:
@@ -78,13 +102,25 @@
             path: "{{ __trust_test_ca_cert }}"
           register: __trust_test_ca_slurp
 
-        - name: Run the role to trust inline certificate content
-          include_tasks: tasks/run_role_with_clear_facts.yml
+        - name: Trust inline certificate content
           vars:
-            __sr_public: true
-            certificate_trust:
-              - name: lsr-trust-test-content
-                content: "{{ __trust_test_ca_slurp.content | b64decode }}"
+            certificate_trust: "{{ __certificate_trust_content }}"
+          block:
+            - name: Run the role to trust inline certificate content
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                __sr_public: true
+
+            - name: Check idempotency if system is booted
+              when: __certificate_is_booted
+              block:
+                - name: Run the role again to test idempotency
+                  include_tasks: tasks/run_role_with_clear_facts.yml
+
+                - name: Assert no changes were made
+                  assert:
+                    that: not certificate_is_changed
+                    fail_msg: "Certificate was changed when it should not have been"
 
         - name: Get the trust anchor file attributes
           stat:
@@ -100,14 +136,14 @@
               - __trust_anchor_content.stat.gr_name == 'root'
 
         - name: Verify that conflicting certificate sources fail validation
+          vars:
+            certificate_trust:
+              - name: lsr-trust-test-invalid
+                content: not-a-certificate
+                url: https://ca.example.com/ca.crt
           block:
             - name: Run the role with conflicting certificate sources
               include_tasks: tasks/run_role_with_clear_facts.yml
-              vars:
-                certificate_trust:
-                  - name: lsr-trust-test-invalid
-                    content: not-a-certificate
-                    url: https://ca.example.com/ca.crt
 
             - name: Failed
               fail:
@@ -122,15 +158,25 @@
                   The role failed for an unexpected reason:
                   {{ ansible_failed_result }}
 
-        - name: Run the role to remove the trust anchors
-          include_tasks: tasks/run_role_with_clear_facts.yml
+        - name: Remove the trust anchors
           vars:
-            __sr_public: true
-            certificate_trust:
-              - name: lsr-trust-test-src
-                state: absent
-              - name: lsr-trust-test-content
-                state: absent
+            certificate_trust: "{{ __certificate_trust_absent }}"
+          block:
+            - name: Run the role to remove the trust anchors
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                __sr_public: true
+
+            - name: Check idempotency if system is booted
+              when: __certificate_is_booted
+              block:
+                - name: Run the role again to test idempotency
+                  include_tasks: tasks/run_role_with_clear_facts.yml
+
+                - name: Assert no changes were made
+                  assert:
+                    that: not certificate_is_changed
+                    fail_msg: "Certificate was changed when it should not have been"
 
         - name: Get the trust anchor file attributes
           stat:
@@ -161,11 +207,7 @@
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             __sr_failed_when: false
-            certificate_trust:
-              - name: lsr-trust-test-src
-                state: absent
-              - name: lsr-trust-test-content
-                state: absent
+            certificate_trust: "{{ __certificate_trust_absent }}"
           tags: tests::cleanup
 
         - name: Clean up the test CA temporary directory


### PR DESCRIPTION
Cause: The key_size from the request was being compared to the key_size read from the
existing certificate file in order to determine if they were different, even if the user
did not specify key_size in the request.

Consequence: If no key_size was specified in the request, the role would report `changed: true`
every time.

Fix: Do not use the `key_size` field for comparison if it was not specified in the request.

Result: The certificate role is idempotent.

Assisted-by: Cursor with models Cursor Grok 4.5, Composer 2.5, Sonnet 5.

This adds idempotency testing to the role.  A new role variable `certificate_is_changed`
is used internally to check if anything changed in the role.  Each role invocation in the
test is run twice to verify idempotency.  The tests_subject_complex has a known failure
on EL10 and later which will be fixed by https://codeberg.org/freeipa/certmonger/pulls/309

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved certificate comparison when optional key-size information is absent.
  - More accurately detects changes from certificate issuance, installation, trust updates, removals, downloads, and service-related operations.

- **Reliability**
  - Repeated role executions now correctly report no changes when the system is already up to date.
  - Trust-store additions and removals are tracked consistently.

- **Tests**
  - Expanded coverage for idempotency across certificate types, key sizes, trust configurations, hooks, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->