### PR TITLE
test: getcert list on el7 does not show issuer_template

### DIFF
--- a/tests/tasks/assert_certificate_parameters.yml
+++ b/tests/tasks/assert_certificate_parameters.yml
@@ -193,6 +193,7 @@
           {{ cert['auto_renew'] | default('yes') | bool }} !=
           {{ result.stdout | bool }}
 
+    # getcert on el7 does not show issuer template, so skip this check
     - name: Retrieve issuer template
       shell: >-
         set -euo pipefail;
@@ -201,7 +202,9 @@
         sed 's/^\s\+issuer template: //g'
       register: result
       changed_when: false
-      when: cert.issuer_template is defined
+      when:
+        - cert.issuer_template is defined
+        - ansible_facts["os_family"] != "RedHat" or ansible_facts["distribution_major_version"] is version("7", ">")
 
     - name: Verify certificate issuer template
       assert:
@@ -210,7 +213,9 @@
         fail_msg: >-
           {{ cert['issuer_template'] | trim }} !=
           {{ result.stdout | trim }}
-      when: cert.issuer_template is defined
+      when:
+        - cert.issuer_template is defined
+        - ansible_facts["os_family"] != "RedHat" or ansible_facts["distribution_major_version"] is version("7", ">")
 
     - name: Stat commands file
       stat:


### PR DESCRIPTION
getcert list on el7 does not show issuer_template, so skip
the check.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted certificate verification behavior on Red Hat 7 systems by skipping issuer-template retrieval and validation.
  * Preserved issuer-template checks on other systems when a template is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->