### PR TITLE
refactor: Relax collection constraints, gate vendored modules by python version, update ci versions [citest_skip]

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -60,7 +60,7 @@ jobs:
             --output ${{ env.RELEASE_VERSION }}/README.html README.md
 
       - name: Upload docs HTML artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: docs-html
           path: ${{ env.RELEASE_VERSION }}/README.html
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Download docs HTML artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: docs-html
           path: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           tag: ${{ steps.tag.outputs.tagname }}
           name: Version ${{ steps.tag.outputs.tagname }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,15 +39,15 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,4 +18,4 @@ jobs:
           persist-credentials: false
 
       - name: Codespell
-        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Ensure use of podman 5
         if: steps.check_platform.outputs.supported && steps.check_podman_version.outputs.need_podman_update == 1
-        uses: redhat-actions/podman-install@3b6c60c447c93960c0b76faa0c66c6694bc71350  # main
+        uses: redhat-actions/podman-install@0499d3899e6b92f60548b38421893a7f8ba4bd07  # main
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
           path: |
@@ -240,7 +240,7 @@ jobs:
 
       - name: Set commit status as success with a description that platform is skipped
         if: ${{ steps.check_platform.outputs.supported == '' }}
-        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         with:
           status: success
           context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -45,7 +45,7 @@ jobs:
             --output README.html README.md
 
       - name: Upload README.html as an artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: README.html
           path: README.html

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Set commit status as pending
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
-        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: pending
@@ -149,7 +149,7 @@ jobs:
 
       - name: Set commit status as success with a description that platform is skipped
         if: "!contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)"
-        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: success
@@ -158,7 +158,7 @@ jobs:
           targetUrl: ""
 
       - name: Run test in testing farm
-        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1  # v4
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1  # v4.3.1
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
           git_ref: main
@@ -187,7 +187,7 @@ jobs:
           tmt_plan_filter: "tag:playbooks_parallel,certificate"
 
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,6 +2,4 @@
 ---
 collections:
   - name: ansible.posix
-    version: '>=2.1.0,<2.2.0'
   - name: community.general
-    version: '>=6.6.0,<12.0.0'

--- a/tests/vars/rh_distros_vars.yml
+++ b/tests/vars/rh_distros_vars.yml
@@ -18,3 +18,9 @@ __certificate_is_rh_distro: "{{ ansible_facts['distribution'] in __certificate_r
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
 __certificate_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __certificate_rh_distros_fedora }}"
+
+# Use these in conditionals to check if distro is Red Hat or clone of a specific major version
+__certificate_is_rh_distro_7: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '7' }}"
+__certificate_is_rh_distro_8: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '8' }}"
+__certificate_is_rh_distro_9: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '9' }}"
+__certificate_is_rh_distro_10: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '10' }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -60,4 +60,10 @@ __certificate_is_rh_distro: "{{ ansible_facts['distribution'] in __certificate_r
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
 __certificate_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __certificate_rh_distros_fedora }}"
+
+# Use these in conditionals to check if distro is Red Hat or clone of a specific major version
+__certificate_is_rh_distro_7: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '7' }}"
+__certificate_is_rh_distro_8: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '8' }}"
+__certificate_is_rh_distro_9: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '9' }}"
+__certificate_is_rh_distro_10: "{{ __certificate_is_rh_distro and ansible_facts['distribution_major_version'] == '10' }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Enhancement:
* Remove the centralized ansible.posix and community.general version caps so all roles track the latest releases.
* Add variables for <rolename>_is_rh_distro_<ver>
* Update CI actions versions

Reason: The caps (ansible.posix <2.2.0, community.general <12.0.0) existed to preserve compatibility with older managed nodes. That is now handled inside the roles by selecting a vendored module or the latest collection module based on the managed node's python version (latest community.general needs python >= 3.7, latest ansible.posix needs python 3), so the central caps are no longer needed.

Result: Roles pick up the latest ansible.posix and community.general, while older-python managed nodes (e.g. EL7) keep working via the vendored modules.
Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
